### PR TITLE
fix: uses `Int` instead of `String` for `cpu` runtime values in WDL tasks

### DIFF
--- a/workflows/controlFREEC_pipeline/controlFREEC_pipeline.wdl
+++ b/workflows/controlFREEC_pipeline/controlFREEC_pipeline.wdl
@@ -827,7 +827,7 @@ CODE
     runtime {
         disks: "local-disk " + ceil(disk_size) + " HDD"
         docker: docker
-        cpu:1
+        cpu: 1
     }
 
 }

--- a/workflows/controlFREEC_pipeline/tasks/general_tasks.wdl
+++ b/workflows/controlFREEC_pipeline/tasks/general_tasks.wdl
@@ -324,7 +324,7 @@ task IntervalListOfGenome {
 
   runtime {
     preemptible: preemptible_tries
-    cpu: "1"
+    cpu: 1
     memory: "1 GB"
     disks: "local-disk " + disk_size + " HDD"
     docker: docker
@@ -359,7 +359,7 @@ task IntervalListFromString {
   >>>
   runtime {
     preemptible: preemptible_tries
-    cpu: "1"
+    cpu: 1
     memory: "1 GB"
     disks: "local-disk " + disk_size + " HDD"
     docker: docker
@@ -395,7 +395,7 @@ task IntervalListTotalLength {
   }
 
    runtime {
-    cpu: "1"
+    cpu: 1
     memory: "1 GB"
     disks: "local-disk " + 4 + " HDD"
     docker: docker
@@ -422,7 +422,7 @@ task FastaLengthFromIndex {
   }
 
    runtime {
-    cpu: "1"
+    cpu: 1
     memory: "1 GB"
     disks: "local-disk " + 4 + " HDD"
     docker: docker
@@ -530,7 +530,7 @@ task DownsampleCramBam {
     >>>
     runtime {
         disks: "local-disk " + disk_size + " HDD"
-        cpu: "~{cpus}"
+        cpu: cpus
         memory: "~{memory_gb} GB"
         preemptible: preemptibles
         docker: docker
@@ -631,7 +631,7 @@ task ConcatHtmls {
         preemptible: preemptible_tries
         memory: "2 GB"
         docker: docker
-        cpu: "1"
+        cpu: 1
         disks: "local-disk " + ceil(disk_size) + " HDD"
         noAddress: true
     }
@@ -700,7 +700,7 @@ task RenameSampleInBam {
     runtime {
         preemptible: preemptible_tries
         memory: "2 GB"
-        cpu: "1"
+        cpu: 1
         disks: "local-disk " + disk_size + " LOCAL"
         docker: docker
         noAddress: no_address
@@ -748,7 +748,7 @@ task MergeCramFiles {
             disks: "local-disk " + (ceil(size(cache_tarball, "GB") + size(crams, "GB")) * 3 + 10) + " HDD"
             docker: docker
             noAddress: no_address
-            cpu: "~{cpus_to_use}"
+            cpu: cpus_to_use
             preemptible: preemptible_tries
 
     }
@@ -773,7 +773,7 @@ task MergeBams {
     runtime {
         preemptible: preemptible_tries
         memory: "16 GB"
-        cpu: "8"
+        cpu: 8
         disks: "local-disk " + disk_size + " LOCAL"
         docker: docker
         noAddress: no_address
@@ -970,7 +970,7 @@ task FilterVcfWithBcftools {
         memory: "~{memory_gb} GB"
         disks: "local-disk " + disk_size + " HDD"
         docker: docker
-        cpu: "~{cpus}"
+        cpu: cpus
         preemptible: preemptible_tries
     }
 }
@@ -1027,7 +1027,7 @@ task ExtractSorterStatsMetrics {
         preemptible: preemptible_tries
         memory: "2 GB"
         docker: docker
-        cpu: "1"
+        cpu: 1
     }
     output {
         Float mean_coverage = read_float("~{mean_coverage_output_file}")
@@ -1048,7 +1048,7 @@ task CopyFiles {
         docker: docker
         preemptible: 1
         memory: "2 GB"
-        cpu: "1"
+        cpu: 1
         disks: "local-disk " +ceil(2*size(input_files,"GB") + 1) + " HDD"
         noAddress: true
     }
@@ -1222,7 +1222,7 @@ task ConcatFiles{
     runtime {
         disks: "local-disk " + ceil(disk_size) + " HDD"
         docker: docker
-        cpu:1
+        cpu: 1
     }
     output{
         File out_merged_file = "~{out_file_name}"

--- a/workflows/controlFREEC_pipeline/tasks/pileup_tasks.wdl
+++ b/workflows/controlFREEC_pipeline/tasks/pileup_tasks.wdl
@@ -44,7 +44,7 @@ task BcftoolsMpileupTask {
     }
     runtime {
       preemptible: "~{preemptibles}"
-      cpu: "~{cpus}"
+      cpu: cpus
       memory: "~{memory_gb} GB"
       disks: "local-disk " + ceil(disk_size) + " HDD"
       docker: docker
@@ -173,7 +173,7 @@ command <<<
         disks: "local-disk " + ceil(disk_size) + " HDD"
         docker: docker
         noAddress: no_address
-        cpu:1
+        cpu: 1
     }
     output {
         File out_pileup = "~{base_input_name}_minipileup.pileup"

--- a/workflows/efficient_dv/tasks/efficient_dv_tasks.wdl
+++ b/workflows/efficient_dv/tasks/efficient_dv_tasks.wdl
@@ -304,7 +304,7 @@ task UGMakeExamples{
   >>>
   runtime {
     memory: "~{memory} GB"
-    cpu: "~{cpu}"
+    cpu: cpu
     disks: "local-disk " + disk_size + " HDD"
     docker: docker
     preemptible: preemptible_tries
@@ -411,7 +411,7 @@ task UGCallVariants{
   >>>
   runtime {
     memory: "~{mem} GB"
-    cpu: "~{num_cpus}"
+    cpu: num_cpus
     disks: "local-disk " + disk_size + " LOCAL"
     docker: docker
     gpuType: "nvidia-tesla-p100"
@@ -631,7 +631,7 @@ task UGPostProcessing{
   >>>
   runtime {
     memory: "8 GB"
-    cpu: "1"
+    cpu: 1
     disks: "local-disk " + disk_size + " HDD"
     docker: docker
     noAddress: no_address
@@ -682,7 +682,7 @@ task QCReport{
   >>>
   runtime {
     memory: "8 GB"
-    cpu: "1"
+    cpu: 1
     disks: "local-disk " + disk_size + " HDD"
     docker: docker
     noAddress: no_address

--- a/workflows/efficient_dv/tasks/general_tasks.wdl
+++ b/workflows/efficient_dv/tasks/general_tasks.wdl
@@ -324,7 +324,7 @@ task IntervalListOfGenome {
 
   runtime {
     preemptible: preemptible_tries
-    cpu: "1"
+    cpu: 1
     memory: "1 GB"
     disks: "local-disk " + disk_size + " HDD"
     docker: docker
@@ -359,7 +359,7 @@ task IntervalListFromString {
   >>>
   runtime {
     preemptible: preemptible_tries
-    cpu: "1"
+    cpu: 1
     memory: "1 GB"
     disks: "local-disk " + disk_size + " HDD"
     docker: docker
@@ -395,7 +395,7 @@ task IntervalListTotalLength {
   }
 
    runtime {
-    cpu: "1"
+    cpu: 1
     memory: "1 GB"
     disks: "local-disk " + 4 + " HDD"
     docker: docker
@@ -422,7 +422,7 @@ task FastaLengthFromIndex {
   }
 
    runtime {
-    cpu: "1"
+    cpu: 1
     memory: "1 GB"
     disks: "local-disk " + 4 + " HDD"
     docker: docker
@@ -530,7 +530,7 @@ task DownsampleCramBam {
     >>>
     runtime {
         disks: "local-disk " + disk_size + " HDD"
-        cpu: "~{cpus}"
+        cpu: cpus
         memory: "~{memory_gb} GB"
         preemptible: preemptibles
         docker: docker
@@ -631,7 +631,7 @@ task ConcatHtmls {
         preemptible: preemptible_tries
         memory: "2 GB"
         docker: docker
-        cpu: "1"
+        cpu: 1
         disks: "local-disk " + ceil(disk_size) + " HDD"
         noAddress: true
     }
@@ -700,7 +700,7 @@ task RenameSampleInBam {
     runtime {
         preemptible: preemptible_tries
         memory: "2 GB"
-        cpu: "1"
+        cpu: 1
         disks: "local-disk " + disk_size + " LOCAL"
         docker: docker
         noAddress: no_address
@@ -748,7 +748,7 @@ task MergeCramFiles {
             disks: "local-disk " + (ceil(size(cache_tarball, "GB") + size(crams, "GB")) * 3 + 10) + " HDD"
             docker: docker
             noAddress: no_address
-            cpu: "~{cpus_to_use}"
+            cpu: cpus_to_use
             preemptible: preemptible_tries
 
     }
@@ -773,7 +773,7 @@ task MergeBams {
     runtime {
         preemptible: preemptible_tries
         memory: "16 GB"
-        cpu: "8"
+        cpu: 8
         disks: "local-disk " + disk_size + " LOCAL"
         docker: docker
         noAddress: no_address
@@ -970,7 +970,7 @@ task FilterVcfWithBcftools {
         memory: "~{memory_gb} GB"
         disks: "local-disk " + disk_size + " HDD"
         docker: docker
-        cpu: "~{cpus}"
+        cpu: cpus
         preemptible: preemptible_tries
     }
 }
@@ -1027,7 +1027,7 @@ task ExtractSorterStatsMetrics {
         preemptible: preemptible_tries
         memory: "2 GB"
         docker: docker
-        cpu: "1"
+        cpu: 1
     }
     output {
         Float mean_coverage = read_float("~{mean_coverage_output_file}")
@@ -1048,7 +1048,7 @@ task CopyFiles {
         docker: docker
         preemptible: 1
         memory: "2 GB"
-        cpu: "1"
+        cpu: 1
         disks: "local-disk " +ceil(2*size(input_files,"GB") + 1) + " HDD"
         noAddress: true
     }
@@ -1222,7 +1222,7 @@ task ConcatFiles{
     runtime {
         disks: "local-disk " + ceil(disk_size) + " HDD"
         docker: docker
-        cpu:1
+        cpu: 1
     }
     output{
         File out_merged_file = "~{out_file_name}"

--- a/workflows/efficient_dv/tasks/single_sample_vc_tasks.wdl
+++ b/workflows/efficient_dv/tasks/single_sample_vc_tasks.wdl
@@ -72,7 +72,7 @@ task HaplotypeCaller {
     runtime {
         preemptible: preemptible_tries
         memory: "~{memory_gb} GB"
-        cpu: "2"
+        cpu: 2
         disks: "local-disk " + disk_size + " HDD"
         docker: docker
         noAddress: no_address
@@ -148,7 +148,7 @@ task ConvertGVCFtoVCF {
   runtime {
     preemptible: preemptible_tries
     memory: "12 GB"
-    cpu: "1"
+    cpu: 1
     disks: "local-disk " + ceil(disk_size) + " HDD"
     docker: docker
     noAddress: no_address
@@ -193,7 +193,7 @@ task CreateSECBlacklist {
   runtime {
     preemptible: preemptible_tries
     memory: "12 GB"
-    cpu: "1"
+    cpu: 1
     disks: "local-disk " + ceil(disk_size) + " HDD"
     docker: docker
     noAddress: no_address
@@ -431,7 +431,7 @@ task NormalizeVariants {
     memory: "3 GB"
     preemptible: preemptible_tries
     noAddress: no_address
-    cpu: "2"
+    cpu: 2
     disks: "local-disk " + disk_size + " HDD"
     docker: docker
   }

--- a/workflows/germline_CNV_pipeline/tasks/general_tasks.wdl
+++ b/workflows/germline_CNV_pipeline/tasks/general_tasks.wdl
@@ -324,7 +324,7 @@ task IntervalListOfGenome {
 
   runtime {
     preemptible: preemptible_tries
-    cpu: "1"
+    cpu: 1
     memory: "1 GB"
     disks: "local-disk " + disk_size + " HDD"
     docker: docker
@@ -359,7 +359,7 @@ task IntervalListFromString {
   >>>
   runtime {
     preemptible: preemptible_tries
-    cpu: "1"
+    cpu: 1
     memory: "1 GB"
     disks: "local-disk " + disk_size + " HDD"
     docker: docker
@@ -395,7 +395,7 @@ task IntervalListTotalLength {
   }
 
    runtime {
-    cpu: "1"
+    cpu: 1
     memory: "1 GB"
     disks: "local-disk " + 4 + " HDD"
     docker: docker
@@ -422,7 +422,7 @@ task FastaLengthFromIndex {
   }
 
    runtime {
-    cpu: "1"
+    cpu: 1
     memory: "1 GB"
     disks: "local-disk " + 4 + " HDD"
     docker: docker
@@ -530,7 +530,7 @@ task DownsampleCramBam {
     >>>
     runtime {
         disks: "local-disk " + disk_size + " HDD"
-        cpu: "~{cpus}"
+        cpu: cpus
         memory: "~{memory_gb} GB"
         preemptible: preemptibles
         docker: docker
@@ -631,7 +631,7 @@ task ConcatHtmls {
         preemptible: preemptible_tries
         memory: "2 GB"
         docker: docker
-        cpu: "1"
+        cpu: 1
         disks: "local-disk " + ceil(disk_size) + " HDD"
         noAddress: true
     }
@@ -700,7 +700,7 @@ task RenameSampleInBam {
     runtime {
         preemptible: preemptible_tries
         memory: "2 GB"
-        cpu: "1"
+        cpu: 1
         disks: "local-disk " + disk_size + " LOCAL"
         docker: docker
         noAddress: no_address
@@ -748,7 +748,7 @@ task MergeCramFiles {
             disks: "local-disk " + (ceil(size(cache_tarball, "GB") + size(crams, "GB")) * 3 + 10) + " HDD"
             docker: docker
             noAddress: no_address
-            cpu: "~{cpus_to_use}"
+            cpu: cpus_to_use
             preemptible: preemptible_tries
 
     }
@@ -773,7 +773,7 @@ task MergeBams {
     runtime {
         preemptible: preemptible_tries
         memory: "16 GB"
-        cpu: "8"
+        cpu: 8
         disks: "local-disk " + disk_size + " LOCAL"
         docker: docker
         noAddress: no_address
@@ -970,7 +970,7 @@ task FilterVcfWithBcftools {
         memory: "~{memory_gb} GB"
         disks: "local-disk " + disk_size + " HDD"
         docker: docker
-        cpu: "~{cpus}"
+        cpu: cpus
         preemptible: preemptible_tries
     }
 }
@@ -1027,7 +1027,7 @@ task ExtractSorterStatsMetrics {
         preemptible: preemptible_tries
         memory: "2 GB"
         docker: docker
-        cpu: "1"
+        cpu: 1
     }
     output {
         Float mean_coverage = read_float("~{mean_coverage_output_file}")
@@ -1048,7 +1048,7 @@ task CopyFiles {
         docker: docker
         preemptible: 1
         memory: "2 GB"
-        cpu: "1"
+        cpu: 1
         disks: "local-disk " +ceil(2*size(input_files,"GB") + 1) + " HDD"
         noAddress: true
     }
@@ -1222,7 +1222,7 @@ task ConcatFiles{
     runtime {
         disks: "local-disk " + ceil(disk_size) + " HDD"
         docker: docker
-        cpu:1
+        cpu: 1
     }
     output{
         File out_merged_file = "~{out_file_name}"

--- a/workflows/germline_CNV_pipeline/tasks/single_sample_vc_tasks.wdl
+++ b/workflows/germline_CNV_pipeline/tasks/single_sample_vc_tasks.wdl
@@ -72,7 +72,7 @@ task HaplotypeCaller {
     runtime {
         preemptible: preemptible_tries
         memory: "~{memory_gb} GB"
-        cpu: "2"
+        cpu: 2
         disks: "local-disk " + disk_size + " HDD"
         docker: docker
         noAddress: no_address
@@ -148,7 +148,7 @@ task ConvertGVCFtoVCF {
   runtime {
     preemptible: preemptible_tries
     memory: "12 GB"
-    cpu: "1"
+    cpu: 1
     disks: "local-disk " + ceil(disk_size) + " HDD"
     docker: docker
     noAddress: no_address
@@ -193,7 +193,7 @@ task CreateSECBlacklist {
   runtime {
     preemptible: preemptible_tries
     memory: "12 GB"
-    cpu: "1"
+    cpu: 1
     disks: "local-disk " + ceil(disk_size) + " HDD"
     docker: docker
     noAddress: no_address
@@ -431,7 +431,7 @@ task NormalizeVariants {
     memory: "3 GB"
     preemptible: preemptible_tries
     noAddress: no_address
-    cpu: "2"
+    cpu: 2
     disks: "local-disk " + disk_size + " HDD"
     docker: docker
   }

--- a/workflows/giraffe_alignment/tasks/alignment_tasks.wdl
+++ b/workflows/giraffe_alignment/tasks/alignment_tasks.wdl
@@ -31,7 +31,7 @@ task SplitCram {
     runtime {
         preemptible: preemptible_tries
         memory: "8 GB"
-        cpu: "1"
+        cpu: 1
         disks: "local-disk " + disk_size + " LOCAL"
         docker: docker
         noAddress: no_address
@@ -115,7 +115,7 @@ task CreateReferenceCache {
     runtime {
         preemptible: preemptible_tries
         memory: "4 GB"
-        cpu: "2"
+        cpu: 2
         disks: "local-disk " + disk_size + " HDD"
         docker: docker
         maxRetries: 1
@@ -177,7 +177,7 @@ task ConvertCramOrBamToUBam {
     runtime {
         preemptible: preemptible_tries
         memory: "13 GB"
-        cpu: "3"
+        cpu: 3
         disks: "local-disk " + disk_size + " HDD"
         docker: docker
         noAddress: no_address
@@ -272,7 +272,7 @@ task SamToFastqAndBwaMemAndMba {
     runtime {
         preemptible: preemptible_tries
         memory: "28 GB"
-        cpu: "16"
+        cpu: 16
         disks: "local-disk " + disk_size + " HDD"
         docker: docker
         noAddress: no_address
@@ -365,7 +365,7 @@ task SamToFastqAndBwaMeth {
     runtime {
         preemptible: preemptible_tries
         memory: "32 GB"
-        cpu: "25"
+        cpu: 25
         disks: "local-disk " + disk_size + " HDD"
         docker: docker
         noAddress: no_address
@@ -409,7 +409,7 @@ task BuildUaIndex{
     >>>
 
     runtime {
-        cpu : "1"
+        cpu: 1
         cpuPlatform: "Intel Skylake"
         preemptible: preemptible_tries
         memory: "200 GB"
@@ -456,7 +456,7 @@ task BuildUaMethIndex {
     >>>
 
     runtime {
-        cpu : "1"
+        cpu: 1
         preemptible: preemptible_tries
         memory: "200 GB"
         disks: "local-disk " + disk_size + " HDD"
@@ -534,7 +534,7 @@ task AlignWithUA {
         cpuPlatform: "Intel Skylake"
         preemptible: preemptible_tries_final
         memory: "~{memory_gb} GiB"
-        cpu: "~{cpu}"
+        cpu: cpu
         disks: "local-disk " + disk_size + " HDD"
         docker: ua_docker
         noAddress: no_address
@@ -615,7 +615,7 @@ task AlignWithUAMeth {
         cpuPlatform: "Intel Skylake"
         preemptible: preemptible_tries_final
         memory: "~{memory_gb} GiB"
-        cpu: "~{cpu}"
+        cpu: cpu
         disks: "local-disk " + disk_size + " HDD"
         docker: ua_docker
         noAddress: no_address
@@ -897,7 +897,7 @@ task ConvertToCram {
     runtime {
         preemptible: preemptible_tries
         memory: "8 GB"
-        cpu: "1"
+        cpu: 1
         disks: "local-disk " + disk_size + " HDD"
         docker: docker
         maxRetries: 1
@@ -1012,7 +1012,7 @@ task StarAlign {
 
     runtime {
         preemptible: "~{preemptible_tries}"
-        cpu: "~{cpu}"
+        cpu: cpu
         memory: "~{memory_gb} GB"
         disks: "local-disk " + ceil(disk_size) + " HDD"
         docker: docker
@@ -1068,7 +1068,7 @@ task StarGenomeGenerate {
 
     runtime {
         preemptible: "~{preemptible_tries}"
-        cpu: "~{cpu}"
+        cpu: cpu
         memory: "40 GB"
         disks: "local-disk " + ceil(disk_size) + " HDD"
         docker: docker
@@ -1127,7 +1127,7 @@ task StarAlignStats {
     >>>
     runtime {
         preemptible: "~{preemptible_tries}"
-        cpu: "1"
+        cpu: 1
         memory: "8 GB"
         disks: "local-disk " + ceil(disk_size) + " HDD"
         docker: docker
@@ -1161,7 +1161,7 @@ task SortBam {
             SORT_ORDER=~{sort_order}
     >>>
     runtime {
-        cpu: "1"
+        cpu: 1
         memory: "8 GB"
         disks: "local-disk " + ceil(disk_size) + " HDD"
         docker: docker
@@ -1192,7 +1192,7 @@ task IndexBam {
         samtools index ~{input_bam}
     >>>  
     runtime {
-        cpu: "1"
+        cpu: 1
         memory: "8 GB"
         disks: "local-disk " + ceil(disk_size) + " HDD"
         docker: docker

--- a/workflows/giraffe_alignment/tasks/sorting_tasks.wdl
+++ b/workflows/giraffe_alignment/tasks/sorting_tasks.wdl
@@ -129,7 +129,7 @@ task Demux {
     >>>
     runtime {
         cpuPlatform: "Intel Skylake"
-        cpu: "~{cpu}"
+        cpu: cpu
         preemptible: preemptible_tries_final
         memory: "~{memory_gb} GiB"
         disks: "local-disk " + ceil(mapped_bam_size_local_ssd) + " LOCAL"
@@ -293,7 +293,7 @@ task Sorter {
     >>>
     runtime {
         cpuPlatform: "Intel Skylake"
-        cpu: "~{cpu}"
+        cpu: cpu
         preemptible: preemptible_tries_final
         memory: "~{memory_gb} GiB"
         disks: "local-disk " + ceil(mapped_bam_size_local_ssd) + " LOCAL"
@@ -371,7 +371,7 @@ task ConvertToFastq {
     >>>
     runtime {
         cpuPlatform: "Intel Skylake"
-        cpu: "~{cpu}"
+        cpu: cpu
         preemptible: preemptible_tries
         memory: "16 GiB"
         disks: "local-disk " + ceil(local_ssd_size_ask) + " LOCAL"

--- a/workflows/hla_genotyping/tasks/general_tasks.wdl
+++ b/workflows/hla_genotyping/tasks/general_tasks.wdl
@@ -324,7 +324,7 @@ task IntervalListOfGenome {
 
   runtime {
     preemptible: preemptible_tries
-    cpu: "1"
+    cpu: 1
     memory: "1 GB"
     disks: "local-disk " + disk_size + " HDD"
     docker: docker
@@ -359,7 +359,7 @@ task IntervalListFromString {
   >>>
   runtime {
     preemptible: preemptible_tries
-    cpu: "1"
+    cpu: 1
     memory: "1 GB"
     disks: "local-disk " + disk_size + " HDD"
     docker: docker
@@ -395,7 +395,7 @@ task IntervalListTotalLength {
   }
 
    runtime {
-    cpu: "1"
+    cpu: 1
     memory: "1 GB"
     disks: "local-disk " + 4 + " HDD"
     docker: docker
@@ -422,7 +422,7 @@ task FastaLengthFromIndex {
   }
 
    runtime {
-    cpu: "1"
+    cpu: 1
     memory: "1 GB"
     disks: "local-disk " + 4 + " HDD"
     docker: docker
@@ -530,7 +530,7 @@ task DownsampleCramBam {
     >>>
     runtime {
         disks: "local-disk " + disk_size + " HDD"
-        cpu: "~{cpus}"
+        cpu: cpus
         memory: "~{memory_gb} GB"
         preemptible: preemptibles
         docker: docker
@@ -631,7 +631,7 @@ task ConcatHtmls {
         preemptible: preemptible_tries
         memory: "2 GB"
         docker: docker
-        cpu: "1"
+        cpu: 1
         disks: "local-disk " + ceil(disk_size) + " HDD"
         noAddress: true
     }
@@ -700,7 +700,7 @@ task RenameSampleInBam {
     runtime {
         preemptible: preemptible_tries
         memory: "2 GB"
-        cpu: "1"
+        cpu: 1
         disks: "local-disk " + disk_size + " LOCAL"
         docker: docker
         noAddress: no_address
@@ -748,7 +748,7 @@ task MergeCramFiles {
             disks: "local-disk " + (ceil(size(cache_tarball, "GB") + size(crams, "GB")) * 3 + 10) + " HDD"
             docker: docker
             noAddress: no_address
-            cpu: "~{cpus_to_use}"
+            cpu: cpus_to_use
             preemptible: preemptible_tries
 
     }
@@ -773,7 +773,7 @@ task MergeBams {
     runtime {
         preemptible: preemptible_tries
         memory: "16 GB"
-        cpu: "8"
+        cpu: 8
         disks: "local-disk " + disk_size + " LOCAL"
         docker: docker
         noAddress: no_address
@@ -970,7 +970,7 @@ task FilterVcfWithBcftools {
         memory: "~{memory_gb} GB"
         disks: "local-disk " + disk_size + " HDD"
         docker: docker
-        cpu: "~{cpus}"
+        cpu: cpus
         preemptible: preemptible_tries
     }
 }
@@ -1027,7 +1027,7 @@ task ExtractSorterStatsMetrics {
         preemptible: preemptible_tries
         memory: "2 GB"
         docker: docker
-        cpu: "1"
+        cpu: 1
     }
     output {
         Float mean_coverage = read_float("~{mean_coverage_output_file}")
@@ -1048,7 +1048,7 @@ task CopyFiles {
         docker: docker
         preemptible: 1
         memory: "2 GB"
-        cpu: "1"
+        cpu: 1
         disks: "local-disk " +ceil(2*size(input_files,"GB") + 1) + " HDD"
         noAddress: true
     }
@@ -1222,7 +1222,7 @@ task ConcatFiles{
     runtime {
         disks: "local-disk " + ceil(disk_size) + " HDD"
         docker: docker
-        cpu:1
+        cpu: 1
     }
     output{
         File out_merged_file = "~{out_file_name}"

--- a/workflows/mrd_featuremap/tasks/general_tasks.wdl
+++ b/workflows/mrd_featuremap/tasks/general_tasks.wdl
@@ -324,7 +324,7 @@ task IntervalListOfGenome {
 
   runtime {
     preemptible: preemptible_tries
-    cpu: "1"
+    cpu: 1
     memory: "1 GB"
     disks: "local-disk " + disk_size + " HDD"
     docker: docker
@@ -359,7 +359,7 @@ task IntervalListFromString {
   >>>
   runtime {
     preemptible: preemptible_tries
-    cpu: "1"
+    cpu: 1
     memory: "1 GB"
     disks: "local-disk " + disk_size + " HDD"
     docker: docker
@@ -395,7 +395,7 @@ task IntervalListTotalLength {
   }
 
    runtime {
-    cpu: "1"
+    cpu: 1
     memory: "1 GB"
     disks: "local-disk " + 4 + " HDD"
     docker: docker
@@ -422,7 +422,7 @@ task FastaLengthFromIndex {
   }
 
    runtime {
-    cpu: "1"
+    cpu: 1
     memory: "1 GB"
     disks: "local-disk " + 4 + " HDD"
     docker: docker
@@ -530,7 +530,7 @@ task DownsampleCramBam {
     >>>
     runtime {
         disks: "local-disk " + disk_size + " HDD"
-        cpu: "~{cpus}"
+        cpu: cpus
         memory: "~{memory_gb} GB"
         preemptible: preemptibles
         docker: docker
@@ -631,7 +631,7 @@ task ConcatHtmls {
         preemptible: preemptible_tries
         memory: "2 GB"
         docker: docker
-        cpu: "1"
+        cpu: 1
         disks: "local-disk " + ceil(disk_size) + " HDD"
         noAddress: true
     }
@@ -700,7 +700,7 @@ task RenameSampleInBam {
     runtime {
         preemptible: preemptible_tries
         memory: "2 GB"
-        cpu: "1"
+        cpu: 1
         disks: "local-disk " + disk_size + " LOCAL"
         docker: docker
         noAddress: no_address
@@ -748,7 +748,7 @@ task MergeCramFiles {
             disks: "local-disk " + (ceil(size(cache_tarball, "GB") + size(crams, "GB")) * 3 + 10) + " HDD"
             docker: docker
             noAddress: no_address
-            cpu: "~{cpus_to_use}"
+            cpu: cpus_to_use
             preemptible: preemptible_tries
 
     }
@@ -773,7 +773,7 @@ task MergeBams {
     runtime {
         preemptible: preemptible_tries
         memory: "16 GB"
-        cpu: "8"
+        cpu: 8
         disks: "local-disk " + disk_size + " LOCAL"
         docker: docker
         noAddress: no_address
@@ -970,7 +970,7 @@ task FilterVcfWithBcftools {
         memory: "~{memory_gb} GB"
         disks: "local-disk " + disk_size + " HDD"
         docker: docker
-        cpu: "~{cpus}"
+        cpu: cpus
         preemptible: preemptible_tries
     }
 }
@@ -1027,7 +1027,7 @@ task ExtractSorterStatsMetrics {
         preemptible: preemptible_tries
         memory: "2 GB"
         docker: docker
-        cpu: "1"
+        cpu: 1
     }
     output {
         Float mean_coverage = read_float("~{mean_coverage_output_file}")
@@ -1048,7 +1048,7 @@ task CopyFiles {
         docker: docker
         preemptible: 1
         memory: "2 GB"
-        cpu: "1"
+        cpu: 1
         disks: "local-disk " +ceil(2*size(input_files,"GB") + 1) + " HDD"
         noAddress: true
     }
@@ -1222,7 +1222,7 @@ task ConcatFiles{
     runtime {
         disks: "local-disk " + ceil(disk_size) + " HDD"
         docker: docker
-        cpu:1
+        cpu: 1
     }
     output{
         File out_merged_file = "~{out_file_name}"

--- a/workflows/mrd_featuremap/tasks/mrd.wdl
+++ b/workflows/mrd_featuremap/tasks/mrd.wdl
@@ -40,7 +40,7 @@ task MrdDataAnalysis {
   >>>
   runtime {
     preemptible: 0
-    cpu: "~{cpus}"
+    cpu: cpus
     memory: "~{memory_gb} GB"
     disks: "local-disk " + ceil(disk_size) + " HDD"
     docker: docker
@@ -84,7 +84,7 @@ task GenerateControlSignaturesFromDatabase {
   >>>
   runtime {
     preemptible: 0
-    cpu: "~{cpus}"
+    cpu: cpus
     memory: "~{memory_gb} GB"
     disks: "local-disk " + ceil(disk_size) + " HDD"
     docker: docker
@@ -144,7 +144,7 @@ task FeatureMapIntersectWithSignatures {
   >>>
   runtime {
     preemptible: 0
-    cpu: "~{cpus}"
+    cpu: cpus
     memory: "~{memory_gb} GB"
     disks: "local-disk " + ceil(disk_size) + " HDD"
     docker: docker
@@ -187,7 +187,7 @@ task BedIntersectAndExclude {
 
     runtime {
       preemptible: "~{preemptibles}"
-      cpu: "~{cpus}"
+      cpu: cpus
       memory: "~{memory_gb} GB"
       disks: "local-disk " + ceil(disk_size) + " HDD"
       docker: docker
@@ -225,7 +225,7 @@ task MergeVcfsIntoBed {
 
     runtime {
       preemptible: "~{preemptibles}"
-      cpu: "~{cpus}"
+      cpu: cpus
       memory: "~{memory_gb} GB"
       disks: "local-disk " + ceil(disk_size) + " HDD"
       docker: docker
@@ -292,7 +292,7 @@ task ExtractCoverageOverVcfFiles {
 
     runtime {
       preemptible: "~{preemptibles}"
-      cpu: "~{cpus}"
+      cpu: cpus
       memory: "~{memory_gb} GB"
       disks: "local-disk " + ceil(disk_size) + " HDD"
       docker: docker
@@ -341,7 +341,7 @@ task PadVcf {
   
   runtime {
     preemptible: preemptible_tries
-    cpu: "~{cpus}"
+    cpu: cpus
     memory: "~{memory_gb} GB"
     disks: "local-disk " + disk_size + " HDD"
     docker: docker

--- a/workflows/ppmSeq_preprocess/tasks/alignment_tasks.wdl
+++ b/workflows/ppmSeq_preprocess/tasks/alignment_tasks.wdl
@@ -31,7 +31,7 @@ task SplitCram {
     runtime {
         preemptible: preemptible_tries
         memory: "8 GB"
-        cpu: "1"
+        cpu: 1
         disks: "local-disk " + disk_size + " LOCAL"
         docker: docker
         noAddress: no_address
@@ -115,7 +115,7 @@ task CreateReferenceCache {
     runtime {
         preemptible: preemptible_tries
         memory: "4 GB"
-        cpu: "2"
+        cpu: 2
         disks: "local-disk " + disk_size + " HDD"
         docker: docker
         maxRetries: 1
@@ -177,7 +177,7 @@ task ConvertCramOrBamToUBam {
     runtime {
         preemptible: preemptible_tries
         memory: "13 GB"
-        cpu: "3"
+        cpu: 3
         disks: "local-disk " + disk_size + " HDD"
         docker: docker
         noAddress: no_address
@@ -272,7 +272,7 @@ task SamToFastqAndBwaMemAndMba {
     runtime {
         preemptible: preemptible_tries
         memory: "28 GB"
-        cpu: "16"
+        cpu: 16
         disks: "local-disk " + disk_size + " HDD"
         docker: docker
         noAddress: no_address
@@ -365,7 +365,7 @@ task SamToFastqAndBwaMeth {
     runtime {
         preemptible: preemptible_tries
         memory: "32 GB"
-        cpu: "25"
+        cpu: 25
         disks: "local-disk " + disk_size + " HDD"
         docker: docker
         noAddress: no_address
@@ -409,7 +409,7 @@ task BuildUaIndex{
     >>>
 
     runtime {
-        cpu : "1"
+        cpu: 1
         cpuPlatform: "Intel Skylake"
         preemptible: preemptible_tries
         memory: "200 GB"
@@ -456,7 +456,7 @@ task BuildUaMethIndex {
     >>>
 
     runtime {
-        cpu : "1"
+        cpu: 1
         preemptible: preemptible_tries
         memory: "200 GB"
         disks: "local-disk " + disk_size + " HDD"
@@ -534,7 +534,7 @@ task AlignWithUA {
         cpuPlatform: "Intel Skylake"
         preemptible: preemptible_tries_final
         memory: "~{memory_gb} GiB"
-        cpu: "~{cpu}"
+        cpu: cpu
         disks: "local-disk " + disk_size + " HDD"
         docker: ua_docker
         noAddress: no_address
@@ -615,7 +615,7 @@ task AlignWithUAMeth {
         cpuPlatform: "Intel Skylake"
         preemptible: preemptible_tries_final
         memory: "~{memory_gb} GiB"
-        cpu: "~{cpu}"
+        cpu: cpu
         disks: "local-disk " + disk_size + " HDD"
         docker: ua_docker
         noAddress: no_address
@@ -897,7 +897,7 @@ task ConvertToCram {
     runtime {
         preemptible: preemptible_tries
         memory: "8 GB"
-        cpu: "1"
+        cpu: 1
         disks: "local-disk " + disk_size + " HDD"
         docker: docker
         maxRetries: 1
@@ -1012,7 +1012,7 @@ task StarAlign {
 
     runtime {
         preemptible: "~{preemptible_tries}"
-        cpu: "~{cpu}"
+        cpu: cpu
         memory: "~{memory_gb} GB"
         disks: "local-disk " + ceil(disk_size) + " HDD"
         docker: docker
@@ -1068,7 +1068,7 @@ task StarGenomeGenerate {
 
     runtime {
         preemptible: "~{preemptible_tries}"
-        cpu: "~{cpu}"
+        cpu: cpu
         memory: "40 GB"
         disks: "local-disk " + ceil(disk_size) + " HDD"
         docker: docker
@@ -1127,7 +1127,7 @@ task StarAlignStats {
     >>>
     runtime {
         preemptible: "~{preemptible_tries}"
-        cpu: "1"
+        cpu: 1
         memory: "8 GB"
         disks: "local-disk " + ceil(disk_size) + " HDD"
         docker: docker
@@ -1161,7 +1161,7 @@ task SortBam {
             SORT_ORDER=~{sort_order}
     >>>
     runtime {
-        cpu: "1"
+        cpu: 1
         memory: "8 GB"
         disks: "local-disk " + ceil(disk_size) + " HDD"
         docker: docker
@@ -1192,7 +1192,7 @@ task IndexBam {
         samtools index ~{input_bam}
     >>>  
     runtime {
-        cpu: "1"
+        cpu: 1
         memory: "8 GB"
         disks: "local-disk " + ceil(disk_size) + " HDD"
         docker: docker

--- a/workflows/ppmSeq_preprocess/tasks/general_tasks.wdl
+++ b/workflows/ppmSeq_preprocess/tasks/general_tasks.wdl
@@ -324,7 +324,7 @@ task IntervalListOfGenome {
 
   runtime {
     preemptible: preemptible_tries
-    cpu: "1"
+    cpu: 1
     memory: "1 GB"
     disks: "local-disk " + disk_size + " HDD"
     docker: docker
@@ -359,7 +359,7 @@ task IntervalListFromString {
   >>>
   runtime {
     preemptible: preemptible_tries
-    cpu: "1"
+    cpu: 1
     memory: "1 GB"
     disks: "local-disk " + disk_size + " HDD"
     docker: docker
@@ -395,7 +395,7 @@ task IntervalListTotalLength {
   }
 
    runtime {
-    cpu: "1"
+    cpu: 1
     memory: "1 GB"
     disks: "local-disk " + 4 + " HDD"
     docker: docker
@@ -422,7 +422,7 @@ task FastaLengthFromIndex {
   }
 
    runtime {
-    cpu: "1"
+    cpu: 1
     memory: "1 GB"
     disks: "local-disk " + 4 + " HDD"
     docker: docker
@@ -530,7 +530,7 @@ task DownsampleCramBam {
     >>>
     runtime {
         disks: "local-disk " + disk_size + " HDD"
-        cpu: "~{cpus}"
+        cpu: cpus
         memory: "~{memory_gb} GB"
         preemptible: preemptibles
         docker: docker
@@ -631,7 +631,7 @@ task ConcatHtmls {
         preemptible: preemptible_tries
         memory: "2 GB"
         docker: docker
-        cpu: "1"
+        cpu: 1
         disks: "local-disk " + ceil(disk_size) + " HDD"
         noAddress: true
     }
@@ -700,7 +700,7 @@ task RenameSampleInBam {
     runtime {
         preemptible: preemptible_tries
         memory: "2 GB"
-        cpu: "1"
+        cpu: 1
         disks: "local-disk " + disk_size + " LOCAL"
         docker: docker
         noAddress: no_address
@@ -748,7 +748,7 @@ task MergeCramFiles {
             disks: "local-disk " + (ceil(size(cache_tarball, "GB") + size(crams, "GB")) * 3 + 10) + " HDD"
             docker: docker
             noAddress: no_address
-            cpu: "~{cpus_to_use}"
+            cpu: cpus_to_use
             preemptible: preemptible_tries
 
     }
@@ -773,7 +773,7 @@ task MergeBams {
     runtime {
         preemptible: preemptible_tries
         memory: "16 GB"
-        cpu: "8"
+        cpu: 8
         disks: "local-disk " + disk_size + " LOCAL"
         docker: docker
         noAddress: no_address
@@ -970,7 +970,7 @@ task FilterVcfWithBcftools {
         memory: "~{memory_gb} GB"
         disks: "local-disk " + disk_size + " HDD"
         docker: docker
-        cpu: "~{cpus}"
+        cpu: cpus
         preemptible: preemptible_tries
     }
 }
@@ -1027,7 +1027,7 @@ task ExtractSorterStatsMetrics {
         preemptible: preemptible_tries
         memory: "2 GB"
         docker: docker
-        cpu: "1"
+        cpu: 1
     }
     output {
         Float mean_coverage = read_float("~{mean_coverage_output_file}")
@@ -1048,7 +1048,7 @@ task CopyFiles {
         docker: docker
         preemptible: 1
         memory: "2 GB"
-        cpu: "1"
+        cpu: 1
         disks: "local-disk " +ceil(2*size(input_files,"GB") + 1) + " HDD"
         noAddress: true
     }
@@ -1222,7 +1222,7 @@ task ConcatFiles{
     runtime {
         disks: "local-disk " + ceil(disk_size) + " HDD"
         docker: docker
-        cpu:1
+        cpu: 1
     }
     output{
         File out_merged_file = "~{out_file_name}"

--- a/workflows/ppmSeq_preprocess/tasks/ppmSeq_preprocess.wdl
+++ b/workflows/ppmSeq_preprocess/tasks/ppmSeq_preprocess.wdl
@@ -37,7 +37,7 @@ task ppmSeqQC {
   >>>
   runtime {
     preemptible: preemptible_tries
-    cpu: "~{cpu}"
+    cpu: cpu
     memory: "~{memory_gb} GB"
     disks: "local-disk " + ceil(disk_size) + " HDD"
     docker: docker

--- a/workflows/ppmSeq_preprocess/tasks/qc_tasks.wdl
+++ b/workflows/ppmSeq_preprocess/tasks/qc_tasks.wdl
@@ -508,7 +508,7 @@ task CollectIntervalCoverageStats {
 
     runtime {
         preemptible: preemptible_tries
-        cpu: "16"
+        cpu: 16
         memory: "16 GB"
         disks: "local-disk " + coverage_stats_disk + " LOCAL"
         docker: docker
@@ -613,7 +613,7 @@ task FastQC {
   runtime
   {
     docker: docker
-    cpu: "~{cpu}"
+    cpu: cpu
     memory: "~{memory_gb} GB"
     disks: "local-disk " + disk_size + " " + disk_type
     noAddress: no_address
@@ -651,7 +651,7 @@ task CreateReportSingleSampleQC {
         preemptible: preemptible_tries
         memory: "3 GB"
         docker: docker
-        cpu: "1"
+        cpu: 1
         disks: "local-disk " + ceil(disk_size) + " HDD"
         noAddress: true
         maxRetries: preemptible_tries

--- a/workflows/ppmSeq_preprocess/tasks/sorting_tasks.wdl
+++ b/workflows/ppmSeq_preprocess/tasks/sorting_tasks.wdl
@@ -129,7 +129,7 @@ task Demux {
     >>>
     runtime {
         cpuPlatform: "Intel Skylake"
-        cpu: "~{cpu}"
+        cpu: cpu
         preemptible: preemptible_tries_final
         memory: "~{memory_gb} GiB"
         disks: "local-disk " + ceil(mapped_bam_size_local_ssd) + " LOCAL"
@@ -293,7 +293,7 @@ task Sorter {
     >>>
     runtime {
         cpuPlatform: "Intel Skylake"
-        cpu: "~{cpu}"
+        cpu: cpu
         preemptible: preemptible_tries_final
         memory: "~{memory_gb} GiB"
         disks: "local-disk " + ceil(mapped_bam_size_local_ssd) + " LOCAL"
@@ -371,7 +371,7 @@ task ConvertToFastq {
     >>>
     runtime {
         cpuPlatform: "Intel Skylake"
-        cpu: "~{cpu}"
+        cpu: cpu
         preemptible: preemptible_tries
         memory: "16 GiB"
         disks: "local-disk " + ceil(local_ssd_size_ask) + " LOCAL"

--- a/workflows/ppmSeq_preprocess/tasks/trimming_tasks.wdl
+++ b/workflows/ppmSeq_preprocess/tasks/trimming_tasks.wdl
@@ -174,7 +174,7 @@ task Trimmer {
     >>>
     runtime {
         cpuPlatform: "Intel Skylake"
-        cpu: "~{cpus}"
+        cpu: cpus
         preemptible: preemptible_tries
         memory: "~{memory_gb} GB"
         disks: "local-disk " + ceil(disk_size) + " HDD"
@@ -228,7 +228,7 @@ task TrimmerAggregateStats {
     >>>
     runtime {
         preemptible: preemptible_tries
-        cpu: "1"
+        cpu: 1
         memory: "5 GB"
         disks: "local-disk " + ceil(disk_size) + " HDD"
         docker: docker
@@ -281,7 +281,7 @@ task CutadaptMarkAdapter {
     }
 
     runtime {
-        cpu: "~{cpus}"
+        cpu: cpus
         memory: "~{memory_gb} GB"
         docker: docker
         noAddress: no_address

--- a/workflows/pypgx/tasks/alignment_tasks.wdl
+++ b/workflows/pypgx/tasks/alignment_tasks.wdl
@@ -31,7 +31,7 @@ task SplitCram {
     runtime {
         preemptible: preemptible_tries
         memory: "8 GB"
-        cpu: "1"
+        cpu: 1
         disks: "local-disk " + disk_size + " LOCAL"
         docker: docker
         noAddress: no_address
@@ -115,7 +115,7 @@ task CreateReferenceCache {
     runtime {
         preemptible: preemptible_tries
         memory: "4 GB"
-        cpu: "2"
+        cpu: 2
         disks: "local-disk " + disk_size + " HDD"
         docker: docker
         maxRetries: 1
@@ -177,7 +177,7 @@ task ConvertCramOrBamToUBam {
     runtime {
         preemptible: preemptible_tries
         memory: "13 GB"
-        cpu: "3"
+        cpu: 3
         disks: "local-disk " + disk_size + " HDD"
         docker: docker
         noAddress: no_address
@@ -272,7 +272,7 @@ task SamToFastqAndBwaMemAndMba {
     runtime {
         preemptible: preemptible_tries
         memory: "28 GB"
-        cpu: "16"
+        cpu: 16
         disks: "local-disk " + disk_size + " HDD"
         docker: docker
         noAddress: no_address
@@ -365,7 +365,7 @@ task SamToFastqAndBwaMeth {
     runtime {
         preemptible: preemptible_tries
         memory: "32 GB"
-        cpu: "25"
+        cpu: 25
         disks: "local-disk " + disk_size + " HDD"
         docker: docker
         noAddress: no_address
@@ -409,7 +409,7 @@ task BuildUaIndex{
     >>>
 
     runtime {
-        cpu : "1"
+        cpu: 1
         cpuPlatform: "Intel Skylake"
         preemptible: preemptible_tries
         memory: "200 GB"
@@ -456,7 +456,7 @@ task BuildUaMethIndex {
     >>>
 
     runtime {
-        cpu : "1"
+        cpu: 1
         preemptible: preemptible_tries
         memory: "200 GB"
         disks: "local-disk " + disk_size + " HDD"
@@ -534,7 +534,7 @@ task AlignWithUA {
         cpuPlatform: "Intel Skylake"
         preemptible: preemptible_tries_final
         memory: "~{memory_gb} GiB"
-        cpu: "~{cpu}"
+        cpu: cpu
         disks: "local-disk " + disk_size + " HDD"
         docker: ua_docker
         noAddress: no_address
@@ -615,7 +615,7 @@ task AlignWithUAMeth {
         cpuPlatform: "Intel Skylake"
         preemptible: preemptible_tries_final
         memory: "~{memory_gb} GiB"
-        cpu: "~{cpu}"
+        cpu: cpu
         disks: "local-disk " + disk_size + " HDD"
         docker: ua_docker
         noAddress: no_address
@@ -897,7 +897,7 @@ task ConvertToCram {
     runtime {
         preemptible: preemptible_tries
         memory: "8 GB"
-        cpu: "1"
+        cpu: 1
         disks: "local-disk " + disk_size + " HDD"
         docker: docker
         maxRetries: 1
@@ -1012,7 +1012,7 @@ task StarAlign {
 
     runtime {
         preemptible: "~{preemptible_tries}"
-        cpu: "~{cpu}"
+        cpu: cpu
         memory: "~{memory_gb} GB"
         disks: "local-disk " + ceil(disk_size) + " HDD"
         docker: docker
@@ -1068,7 +1068,7 @@ task StarGenomeGenerate {
 
     runtime {
         preemptible: "~{preemptible_tries}"
-        cpu: "~{cpu}"
+        cpu: cpu
         memory: "40 GB"
         disks: "local-disk " + ceil(disk_size) + " HDD"
         docker: docker
@@ -1127,7 +1127,7 @@ task StarAlignStats {
     >>>
     runtime {
         preemptible: "~{preemptible_tries}"
-        cpu: "1"
+        cpu: 1
         memory: "8 GB"
         disks: "local-disk " + ceil(disk_size) + " HDD"
         docker: docker
@@ -1161,7 +1161,7 @@ task SortBam {
             SORT_ORDER=~{sort_order}
     >>>
     runtime {
-        cpu: "1"
+        cpu: 1
         memory: "8 GB"
         disks: "local-disk " + ceil(disk_size) + " HDD"
         docker: docker
@@ -1192,7 +1192,7 @@ task IndexBam {
         samtools index ~{input_bam}
     >>>  
     runtime {
-        cpu: "1"
+        cpu: 1
         memory: "8 GB"
         disks: "local-disk " + ceil(disk_size) + " HDD"
         docker: docker

--- a/workflows/pypgx/tasks/efficient_dv_tasks.wdl
+++ b/workflows/pypgx/tasks/efficient_dv_tasks.wdl
@@ -304,7 +304,7 @@ task UGMakeExamples{
   >>>
   runtime {
     memory: "~{memory} GB"
-    cpu: "~{cpu}"
+    cpu: cpu
     disks: "local-disk " + disk_size + " HDD"
     docker: docker
     preemptible: preemptible_tries
@@ -411,7 +411,7 @@ task UGCallVariants{
   >>>
   runtime {
     memory: "~{mem} GB"
-    cpu: "~{num_cpus}"
+    cpu: num_cpus
     disks: "local-disk " + disk_size + " LOCAL"
     docker: docker
     gpuType: "nvidia-tesla-p100"
@@ -631,7 +631,7 @@ task UGPostProcessing{
   >>>
   runtime {
     memory: "8 GB"
-    cpu: "1"
+    cpu: 1
     disks: "local-disk " + disk_size + " HDD"
     docker: docker
     noAddress: no_address
@@ -682,7 +682,7 @@ task QCReport{
   >>>
   runtime {
     memory: "8 GB"
-    cpu: "1"
+    cpu: 1
     disks: "local-disk " + disk_size + " HDD"
     docker: docker
     noAddress: no_address

--- a/workflows/pypgx/tasks/general_tasks.wdl
+++ b/workflows/pypgx/tasks/general_tasks.wdl
@@ -324,7 +324,7 @@ task IntervalListOfGenome {
 
   runtime {
     preemptible: preemptible_tries
-    cpu: "1"
+    cpu: 1
     memory: "1 GB"
     disks: "local-disk " + disk_size + " HDD"
     docker: docker
@@ -359,7 +359,7 @@ task IntervalListFromString {
   >>>
   runtime {
     preemptible: preemptible_tries
-    cpu: "1"
+    cpu: 1
     memory: "1 GB"
     disks: "local-disk " + disk_size + " HDD"
     docker: docker
@@ -395,7 +395,7 @@ task IntervalListTotalLength {
   }
 
    runtime {
-    cpu: "1"
+    cpu: 1
     memory: "1 GB"
     disks: "local-disk " + 4 + " HDD"
     docker: docker
@@ -422,7 +422,7 @@ task FastaLengthFromIndex {
   }
 
    runtime {
-    cpu: "1"
+    cpu: 1
     memory: "1 GB"
     disks: "local-disk " + 4 + " HDD"
     docker: docker
@@ -530,7 +530,7 @@ task DownsampleCramBam {
     >>>
     runtime {
         disks: "local-disk " + disk_size + " HDD"
-        cpu: "~{cpus}"
+        cpu: cpus
         memory: "~{memory_gb} GB"
         preemptible: preemptibles
         docker: docker
@@ -631,7 +631,7 @@ task ConcatHtmls {
         preemptible: preemptible_tries
         memory: "2 GB"
         docker: docker
-        cpu: "1"
+        cpu: 1
         disks: "local-disk " + ceil(disk_size) + " HDD"
         noAddress: true
     }
@@ -700,7 +700,7 @@ task RenameSampleInBam {
     runtime {
         preemptible: preemptible_tries
         memory: "2 GB"
-        cpu: "1"
+        cpu: 1
         disks: "local-disk " + disk_size + " LOCAL"
         docker: docker
         noAddress: no_address
@@ -748,7 +748,7 @@ task MergeCramFiles {
             disks: "local-disk " + (ceil(size(cache_tarball, "GB") + size(crams, "GB")) * 3 + 10) + " HDD"
             docker: docker
             noAddress: no_address
-            cpu: "~{cpus_to_use}"
+            cpu: cpus_to_use
             preemptible: preemptible_tries
 
     }
@@ -773,7 +773,7 @@ task MergeBams {
     runtime {
         preemptible: preemptible_tries
         memory: "16 GB"
-        cpu: "8"
+        cpu: 8
         disks: "local-disk " + disk_size + " LOCAL"
         docker: docker
         noAddress: no_address
@@ -970,7 +970,7 @@ task FilterVcfWithBcftools {
         memory: "~{memory_gb} GB"
         disks: "local-disk " + disk_size + " HDD"
         docker: docker
-        cpu: "~{cpus}"
+        cpu: cpus
         preemptible: preemptible_tries
     }
 }
@@ -1027,7 +1027,7 @@ task ExtractSorterStatsMetrics {
         preemptible: preemptible_tries
         memory: "2 GB"
         docker: docker
-        cpu: "1"
+        cpu: 1
     }
     output {
         Float mean_coverage = read_float("~{mean_coverage_output_file}")
@@ -1048,7 +1048,7 @@ task CopyFiles {
         docker: docker
         preemptible: 1
         memory: "2 GB"
-        cpu: "1"
+        cpu: 1
         disks: "local-disk " +ceil(2*size(input_files,"GB") + 1) + " HDD"
         noAddress: true
     }
@@ -1222,7 +1222,7 @@ task ConcatFiles{
     runtime {
         disks: "local-disk " + ceil(disk_size) + " HDD"
         docker: docker
-        cpu:1
+        cpu: 1
     }
     output{
         File out_merged_file = "~{out_file_name}"

--- a/workflows/pypgx/tasks/single_sample_vc_tasks.wdl
+++ b/workflows/pypgx/tasks/single_sample_vc_tasks.wdl
@@ -72,7 +72,7 @@ task HaplotypeCaller {
     runtime {
         preemptible: preemptible_tries
         memory: "~{memory_gb} GB"
-        cpu: "2"
+        cpu: 2
         disks: "local-disk " + disk_size + " HDD"
         docker: docker
         noAddress: no_address
@@ -148,7 +148,7 @@ task ConvertGVCFtoVCF {
   runtime {
     preemptible: preemptible_tries
     memory: "12 GB"
-    cpu: "1"
+    cpu: 1
     disks: "local-disk " + ceil(disk_size) + " HDD"
     docker: docker
     noAddress: no_address
@@ -193,7 +193,7 @@ task CreateSECBlacklist {
   runtime {
     preemptible: preemptible_tries
     memory: "12 GB"
-    cpu: "1"
+    cpu: 1
     disks: "local-disk " + ceil(disk_size) + " HDD"
     docker: docker
     noAddress: no_address
@@ -431,7 +431,7 @@ task NormalizeVariants {
     memory: "3 GB"
     preemptible: preemptible_tries
     noAddress: no_address
-    cpu: "2"
+    cpu: 2
     disks: "local-disk " + disk_size + " HDD"
     docker: docker
   }

--- a/workflows/segdup/tasks/efficient_dv_tasks.wdl
+++ b/workflows/segdup/tasks/efficient_dv_tasks.wdl
@@ -304,7 +304,7 @@ task UGMakeExamples{
   >>>
   runtime {
     memory: "~{memory} GB"
-    cpu: "~{cpu}"
+    cpu: cpu
     disks: "local-disk " + disk_size + " HDD"
     docker: docker
     preemptible: preemptible_tries
@@ -411,7 +411,7 @@ task UGCallVariants{
   >>>
   runtime {
     memory: "~{mem} GB"
-    cpu: "~{num_cpus}"
+    cpu: num_cpus
     disks: "local-disk " + disk_size + " LOCAL"
     docker: docker
     gpuType: "nvidia-tesla-p100"
@@ -631,7 +631,7 @@ task UGPostProcessing{
   >>>
   runtime {
     memory: "8 GB"
-    cpu: "1"
+    cpu: 1
     disks: "local-disk " + disk_size + " HDD"
     docker: docker
     noAddress: no_address
@@ -682,7 +682,7 @@ task QCReport{
   >>>
   runtime {
     memory: "8 GB"
-    cpu: "1"
+    cpu: 1
     disks: "local-disk " + disk_size + " HDD"
     docker: docker
     noAddress: no_address

--- a/workflows/segdup/tasks/general_tasks.wdl
+++ b/workflows/segdup/tasks/general_tasks.wdl
@@ -324,7 +324,7 @@ task IntervalListOfGenome {
 
   runtime {
     preemptible: preemptible_tries
-    cpu: "1"
+    cpu: 1
     memory: "1 GB"
     disks: "local-disk " + disk_size + " HDD"
     docker: docker
@@ -359,7 +359,7 @@ task IntervalListFromString {
   >>>
   runtime {
     preemptible: preemptible_tries
-    cpu: "1"
+    cpu: 1
     memory: "1 GB"
     disks: "local-disk " + disk_size + " HDD"
     docker: docker
@@ -395,7 +395,7 @@ task IntervalListTotalLength {
   }
 
    runtime {
-    cpu: "1"
+    cpu: 1
     memory: "1 GB"
     disks: "local-disk " + 4 + " HDD"
     docker: docker
@@ -422,7 +422,7 @@ task FastaLengthFromIndex {
   }
 
    runtime {
-    cpu: "1"
+    cpu: 1
     memory: "1 GB"
     disks: "local-disk " + 4 + " HDD"
     docker: docker
@@ -530,7 +530,7 @@ task DownsampleCramBam {
     >>>
     runtime {
         disks: "local-disk " + disk_size + " HDD"
-        cpu: "~{cpus}"
+        cpu: cpus
         memory: "~{memory_gb} GB"
         preemptible: preemptibles
         docker: docker
@@ -631,7 +631,7 @@ task ConcatHtmls {
         preemptible: preemptible_tries
         memory: "2 GB"
         docker: docker
-        cpu: "1"
+        cpu: 1
         disks: "local-disk " + ceil(disk_size) + " HDD"
         noAddress: true
     }
@@ -700,7 +700,7 @@ task RenameSampleInBam {
     runtime {
         preemptible: preemptible_tries
         memory: "2 GB"
-        cpu: "1"
+        cpu: 1
         disks: "local-disk " + disk_size + " LOCAL"
         docker: docker
         noAddress: no_address
@@ -748,7 +748,7 @@ task MergeCramFiles {
             disks: "local-disk " + (ceil(size(cache_tarball, "GB") + size(crams, "GB")) * 3 + 10) + " HDD"
             docker: docker
             noAddress: no_address
-            cpu: "~{cpus_to_use}"
+            cpu: cpus_to_use
             preemptible: preemptible_tries
 
     }
@@ -773,7 +773,7 @@ task MergeBams {
     runtime {
         preemptible: preemptible_tries
         memory: "16 GB"
-        cpu: "8"
+        cpu: 8
         disks: "local-disk " + disk_size + " LOCAL"
         docker: docker
         noAddress: no_address
@@ -970,7 +970,7 @@ task FilterVcfWithBcftools {
         memory: "~{memory_gb} GB"
         disks: "local-disk " + disk_size + " HDD"
         docker: docker
-        cpu: "~{cpus}"
+        cpu: cpus
         preemptible: preemptible_tries
     }
 }
@@ -1027,7 +1027,7 @@ task ExtractSorterStatsMetrics {
         preemptible: preemptible_tries
         memory: "2 GB"
         docker: docker
-        cpu: "1"
+        cpu: 1
     }
     output {
         Float mean_coverage = read_float("~{mean_coverage_output_file}")
@@ -1048,7 +1048,7 @@ task CopyFiles {
         docker: docker
         preemptible: 1
         memory: "2 GB"
-        cpu: "1"
+        cpu: 1
         disks: "local-disk " +ceil(2*size(input_files,"GB") + 1) + " HDD"
         noAddress: true
     }
@@ -1222,7 +1222,7 @@ task ConcatFiles{
     runtime {
         disks: "local-disk " + ceil(disk_size) + " HDD"
         docker: docker
-        cpu:1
+        cpu: 1
     }
     output{
         File out_merged_file = "~{out_file_name}"

--- a/workflows/segdup/tasks/single_sample_vc_tasks.wdl
+++ b/workflows/segdup/tasks/single_sample_vc_tasks.wdl
@@ -72,7 +72,7 @@ task HaplotypeCaller {
     runtime {
         preemptible: preemptible_tries
         memory: "~{memory_gb} GB"
-        cpu: "2"
+        cpu: 2
         disks: "local-disk " + disk_size + " HDD"
         docker: docker
         noAddress: no_address
@@ -148,7 +148,7 @@ task ConvertGVCFtoVCF {
   runtime {
     preemptible: preemptible_tries
     memory: "12 GB"
-    cpu: "1"
+    cpu: 1
     disks: "local-disk " + ceil(disk_size) + " HDD"
     docker: docker
     noAddress: no_address
@@ -193,7 +193,7 @@ task CreateSECBlacklist {
   runtime {
     preemptible: preemptible_tries
     memory: "12 GB"
-    cpu: "1"
+    cpu: 1
     disks: "local-disk " + ceil(disk_size) + " HDD"
     docker: docker
     noAddress: no_address
@@ -431,7 +431,7 @@ task NormalizeVariants {
     memory: "3 GB"
     preemptible: preemptible_tries
     noAddress: no_address
-    cpu: "2"
+    cpu: 2
     disks: "local-disk " + disk_size + " HDD"
     docker: docker
   }

--- a/workflows/single_cell_general/tasks/alignment_tasks.wdl
+++ b/workflows/single_cell_general/tasks/alignment_tasks.wdl
@@ -31,7 +31,7 @@ task SplitCram {
     runtime {
         preemptible: preemptible_tries
         memory: "8 GB"
-        cpu: "1"
+        cpu: 1
         disks: "local-disk " + disk_size + " LOCAL"
         docker: docker
         noAddress: no_address
@@ -115,7 +115,7 @@ task CreateReferenceCache {
     runtime {
         preemptible: preemptible_tries
         memory: "4 GB"
-        cpu: "2"
+        cpu: 2
         disks: "local-disk " + disk_size + " HDD"
         docker: docker
         maxRetries: 1
@@ -177,7 +177,7 @@ task ConvertCramOrBamToUBam {
     runtime {
         preemptible: preemptible_tries
         memory: "13 GB"
-        cpu: "3"
+        cpu: 3
         disks: "local-disk " + disk_size + " HDD"
         docker: docker
         noAddress: no_address
@@ -272,7 +272,7 @@ task SamToFastqAndBwaMemAndMba {
     runtime {
         preemptible: preemptible_tries
         memory: "28 GB"
-        cpu: "16"
+        cpu: 16
         disks: "local-disk " + disk_size + " HDD"
         docker: docker
         noAddress: no_address
@@ -365,7 +365,7 @@ task SamToFastqAndBwaMeth {
     runtime {
         preemptible: preemptible_tries
         memory: "32 GB"
-        cpu: "25"
+        cpu: 25
         disks: "local-disk " + disk_size + " HDD"
         docker: docker
         noAddress: no_address
@@ -409,7 +409,7 @@ task BuildUaIndex{
     >>>
 
     runtime {
-        cpu : "1"
+        cpu: 1
         cpuPlatform: "Intel Skylake"
         preemptible: preemptible_tries
         memory: "200 GB"
@@ -456,7 +456,7 @@ task BuildUaMethIndex {
     >>>
 
     runtime {
-        cpu : "1"
+        cpu: 1
         preemptible: preemptible_tries
         memory: "200 GB"
         disks: "local-disk " + disk_size + " HDD"
@@ -534,7 +534,7 @@ task AlignWithUA {
         cpuPlatform: "Intel Skylake"
         preemptible: preemptible_tries_final
         memory: "~{memory_gb} GiB"
-        cpu: "~{cpu}"
+        cpu: cpu
         disks: "local-disk " + disk_size + " HDD"
         docker: ua_docker
         noAddress: no_address
@@ -615,7 +615,7 @@ task AlignWithUAMeth {
         cpuPlatform: "Intel Skylake"
         preemptible: preemptible_tries_final
         memory: "~{memory_gb} GiB"
-        cpu: "~{cpu}"
+        cpu: cpu
         disks: "local-disk " + disk_size + " HDD"
         docker: ua_docker
         noAddress: no_address
@@ -897,7 +897,7 @@ task ConvertToCram {
     runtime {
         preemptible: preemptible_tries
         memory: "8 GB"
-        cpu: "1"
+        cpu: 1
         disks: "local-disk " + disk_size + " HDD"
         docker: docker
         maxRetries: 1
@@ -1012,7 +1012,7 @@ task StarAlign {
 
     runtime {
         preemptible: "~{preemptible_tries}"
-        cpu: "~{cpu}"
+        cpu: cpu
         memory: "~{memory_gb} GB"
         disks: "local-disk " + ceil(disk_size) + " HDD"
         docker: docker
@@ -1068,7 +1068,7 @@ task StarGenomeGenerate {
 
     runtime {
         preemptible: "~{preemptible_tries}"
-        cpu: "~{cpu}"
+        cpu: cpu
         memory: "40 GB"
         disks: "local-disk " + ceil(disk_size) + " HDD"
         docker: docker
@@ -1127,7 +1127,7 @@ task StarAlignStats {
     >>>
     runtime {
         preemptible: "~{preemptible_tries}"
-        cpu: "1"
+        cpu: 1
         memory: "8 GB"
         disks: "local-disk " + ceil(disk_size) + " HDD"
         docker: docker
@@ -1161,7 +1161,7 @@ task SortBam {
             SORT_ORDER=~{sort_order}
     >>>
     runtime {
-        cpu: "1"
+        cpu: 1
         memory: "8 GB"
         disks: "local-disk " + ceil(disk_size) + " HDD"
         docker: docker
@@ -1192,7 +1192,7 @@ task IndexBam {
         samtools index ~{input_bam}
     >>>  
     runtime {
-        cpu: "1"
+        cpu: 1
         memory: "8 GB"
         disks: "local-disk " + ceil(disk_size) + " HDD"
         docker: docker

--- a/workflows/single_cell_general/tasks/general_tasks.wdl
+++ b/workflows/single_cell_general/tasks/general_tasks.wdl
@@ -324,7 +324,7 @@ task IntervalListOfGenome {
 
   runtime {
     preemptible: preemptible_tries
-    cpu: "1"
+    cpu: 1
     memory: "1 GB"
     disks: "local-disk " + disk_size + " HDD"
     docker: docker
@@ -359,7 +359,7 @@ task IntervalListFromString {
   >>>
   runtime {
     preemptible: preemptible_tries
-    cpu: "1"
+    cpu: 1
     memory: "1 GB"
     disks: "local-disk " + disk_size + " HDD"
     docker: docker
@@ -395,7 +395,7 @@ task IntervalListTotalLength {
   }
 
    runtime {
-    cpu: "1"
+    cpu: 1
     memory: "1 GB"
     disks: "local-disk " + 4 + " HDD"
     docker: docker
@@ -422,7 +422,7 @@ task FastaLengthFromIndex {
   }
 
    runtime {
-    cpu: "1"
+    cpu: 1
     memory: "1 GB"
     disks: "local-disk " + 4 + " HDD"
     docker: docker
@@ -530,7 +530,7 @@ task DownsampleCramBam {
     >>>
     runtime {
         disks: "local-disk " + disk_size + " HDD"
-        cpu: "~{cpus}"
+        cpu: cpus
         memory: "~{memory_gb} GB"
         preemptible: preemptibles
         docker: docker
@@ -631,7 +631,7 @@ task ConcatHtmls {
         preemptible: preemptible_tries
         memory: "2 GB"
         docker: docker
-        cpu: "1"
+        cpu: 1
         disks: "local-disk " + ceil(disk_size) + " HDD"
         noAddress: true
     }
@@ -700,7 +700,7 @@ task RenameSampleInBam {
     runtime {
         preemptible: preemptible_tries
         memory: "2 GB"
-        cpu: "1"
+        cpu: 1
         disks: "local-disk " + disk_size + " LOCAL"
         docker: docker
         noAddress: no_address
@@ -748,7 +748,7 @@ task MergeCramFiles {
             disks: "local-disk " + (ceil(size(cache_tarball, "GB") + size(crams, "GB")) * 3 + 10) + " HDD"
             docker: docker
             noAddress: no_address
-            cpu: "~{cpus_to_use}"
+            cpu: cpus_to_use
             preemptible: preemptible_tries
 
     }
@@ -773,7 +773,7 @@ task MergeBams {
     runtime {
         preemptible: preemptible_tries
         memory: "16 GB"
-        cpu: "8"
+        cpu: 8
         disks: "local-disk " + disk_size + " LOCAL"
         docker: docker
         noAddress: no_address
@@ -970,7 +970,7 @@ task FilterVcfWithBcftools {
         memory: "~{memory_gb} GB"
         disks: "local-disk " + disk_size + " HDD"
         docker: docker
-        cpu: "~{cpus}"
+        cpu: cpus
         preemptible: preemptible_tries
     }
 }
@@ -1027,7 +1027,7 @@ task ExtractSorterStatsMetrics {
         preemptible: preemptible_tries
         memory: "2 GB"
         docker: docker
-        cpu: "1"
+        cpu: 1
     }
     output {
         Float mean_coverage = read_float("~{mean_coverage_output_file}")
@@ -1048,7 +1048,7 @@ task CopyFiles {
         docker: docker
         preemptible: 1
         memory: "2 GB"
-        cpu: "1"
+        cpu: 1
         disks: "local-disk " +ceil(2*size(input_files,"GB") + 1) + " HDD"
         noAddress: true
     }
@@ -1222,7 +1222,7 @@ task ConcatFiles{
     runtime {
         disks: "local-disk " + ceil(disk_size) + " HDD"
         docker: docker
-        cpu:1
+        cpu: 1
     }
     output{
         File out_merged_file = "~{out_file_name}"

--- a/workflows/single_cell_general/tasks/qc_tasks.wdl
+++ b/workflows/single_cell_general/tasks/qc_tasks.wdl
@@ -508,7 +508,7 @@ task CollectIntervalCoverageStats {
 
     runtime {
         preemptible: preemptible_tries
-        cpu: "16"
+        cpu: 16
         memory: "16 GB"
         disks: "local-disk " + coverage_stats_disk + " LOCAL"
         docker: docker
@@ -613,7 +613,7 @@ task FastQC {
   runtime
   {
     docker: docker
-    cpu: "~{cpu}"
+    cpu: cpu
     memory: "~{memory_gb} GB"
     disks: "local-disk " + disk_size + " " + disk_type
     noAddress: no_address
@@ -651,7 +651,7 @@ task CreateReportSingleSampleQC {
         preemptible: preemptible_tries
         memory: "3 GB"
         docker: docker
-        cpu: "1"
+        cpu: 1
         disks: "local-disk " + ceil(disk_size) + " HDD"
         noAddress: true
         maxRetries: preemptible_tries

--- a/workflows/single_cell_general/tasks/single_cell_tasks.wdl
+++ b/workflows/single_cell_general/tasks/single_cell_tasks.wdl
@@ -77,7 +77,7 @@ task StarSolo {
 
     runtime {
         preemptible: "~{preemptible_tries}"
-        cpu: "~{cpu}"
+        cpu: cpu
         memory: "64 GB"
         disks: "local-disk " + ceil(disk_size) + " HDD"
         docker: docker

--- a/workflows/single_cell_general/tasks/sorting_tasks.wdl
+++ b/workflows/single_cell_general/tasks/sorting_tasks.wdl
@@ -129,7 +129,7 @@ task Demux {
     >>>
     runtime {
         cpuPlatform: "Intel Skylake"
-        cpu: "~{cpu}"
+        cpu: cpu
         preemptible: preemptible_tries_final
         memory: "~{memory_gb} GiB"
         disks: "local-disk " + ceil(mapped_bam_size_local_ssd) + " LOCAL"
@@ -293,7 +293,7 @@ task Sorter {
     >>>
     runtime {
         cpuPlatform: "Intel Skylake"
-        cpu: "~{cpu}"
+        cpu: cpu
         preemptible: preemptible_tries_final
         memory: "~{memory_gb} GiB"
         disks: "local-disk " + ceil(mapped_bam_size_local_ssd) + " LOCAL"
@@ -371,7 +371,7 @@ task ConvertToFastq {
     >>>
     runtime {
         cpuPlatform: "Intel Skylake"
-        cpu: "~{cpu}"
+        cpu: cpu
         preemptible: preemptible_tries
         memory: "16 GiB"
         disks: "local-disk " + ceil(local_ssd_size_ask) + " LOCAL"

--- a/workflows/single_cell_general/tasks/trimming_tasks.wdl
+++ b/workflows/single_cell_general/tasks/trimming_tasks.wdl
@@ -174,7 +174,7 @@ task Trimmer {
     >>>
     runtime {
         cpuPlatform: "Intel Skylake"
-        cpu: "~{cpus}"
+        cpu: cpus
         preemptible: preemptible_tries
         memory: "~{memory_gb} GB"
         disks: "local-disk " + ceil(disk_size) + " HDD"
@@ -228,7 +228,7 @@ task TrimmerAggregateStats {
     >>>
     runtime {
         preemptible: preemptible_tries
-        cpu: "1"
+        cpu: 1
         memory: "5 GB"
         disks: "local-disk " + ceil(disk_size) + " HDD"
         docker: docker
@@ -281,7 +281,7 @@ task CutadaptMarkAdapter {
     }
 
     runtime {
-        cpu: "~{cpus}"
+        cpu: cpus
         memory: "~{memory_gb} GB"
         docker: docker
         noAddress: no_address

--- a/workflows/single_read_snv/tasks/general_tasks.wdl
+++ b/workflows/single_read_snv/tasks/general_tasks.wdl
@@ -324,7 +324,7 @@ task IntervalListOfGenome {
 
   runtime {
     preemptible: preemptible_tries
-    cpu: "1"
+    cpu: 1
     memory: "1 GB"
     disks: "local-disk " + disk_size + " HDD"
     docker: docker
@@ -359,7 +359,7 @@ task IntervalListFromString {
   >>>
   runtime {
     preemptible: preemptible_tries
-    cpu: "1"
+    cpu: 1
     memory: "1 GB"
     disks: "local-disk " + disk_size + " HDD"
     docker: docker
@@ -395,7 +395,7 @@ task IntervalListTotalLength {
   }
 
    runtime {
-    cpu: "1"
+    cpu: 1
     memory: "1 GB"
     disks: "local-disk " + 4 + " HDD"
     docker: docker
@@ -422,7 +422,7 @@ task FastaLengthFromIndex {
   }
 
    runtime {
-    cpu: "1"
+    cpu: 1
     memory: "1 GB"
     disks: "local-disk " + 4 + " HDD"
     docker: docker
@@ -530,7 +530,7 @@ task DownsampleCramBam {
     >>>
     runtime {
         disks: "local-disk " + disk_size + " HDD"
-        cpu: "~{cpus}"
+        cpu: cpus
         memory: "~{memory_gb} GB"
         preemptible: preemptibles
         docker: docker
@@ -631,7 +631,7 @@ task ConcatHtmls {
         preemptible: preemptible_tries
         memory: "2 GB"
         docker: docker
-        cpu: "1"
+        cpu: 1
         disks: "local-disk " + ceil(disk_size) + " HDD"
         noAddress: true
     }
@@ -700,7 +700,7 @@ task RenameSampleInBam {
     runtime {
         preemptible: preemptible_tries
         memory: "2 GB"
-        cpu: "1"
+        cpu: 1
         disks: "local-disk " + disk_size + " LOCAL"
         docker: docker
         noAddress: no_address
@@ -748,7 +748,7 @@ task MergeCramFiles {
             disks: "local-disk " + (ceil(size(cache_tarball, "GB") + size(crams, "GB")) * 3 + 10) + " HDD"
             docker: docker
             noAddress: no_address
-            cpu: "~{cpus_to_use}"
+            cpu: cpus_to_use
             preemptible: preemptible_tries
 
     }
@@ -773,7 +773,7 @@ task MergeBams {
     runtime {
         preemptible: preemptible_tries
         memory: "16 GB"
-        cpu: "8"
+        cpu: 8
         disks: "local-disk " + disk_size + " LOCAL"
         docker: docker
         noAddress: no_address
@@ -970,7 +970,7 @@ task FilterVcfWithBcftools {
         memory: "~{memory_gb} GB"
         disks: "local-disk " + disk_size + " HDD"
         docker: docker
-        cpu: "~{cpus}"
+        cpu: cpus
         preemptible: preemptible_tries
     }
 }
@@ -1027,7 +1027,7 @@ task ExtractSorterStatsMetrics {
         preemptible: preemptible_tries
         memory: "2 GB"
         docker: docker
-        cpu: "1"
+        cpu: 1
     }
     output {
         Float mean_coverage = read_float("~{mean_coverage_output_file}")
@@ -1048,7 +1048,7 @@ task CopyFiles {
         docker: docker
         preemptible: 1
         memory: "2 GB"
-        cpu: "1"
+        cpu: 1
         disks: "local-disk " +ceil(2*size(input_files,"GB") + 1) + " HDD"
         noAddress: true
     }
@@ -1222,7 +1222,7 @@ task ConcatFiles{
     runtime {
         disks: "local-disk " + ceil(disk_size) + " HDD"
         docker: docker
-        cpu:1
+        cpu: 1
     }
     output{
         File out_merged_file = "~{out_file_name}"

--- a/workflows/single_read_snv/tasks/mrd.wdl
+++ b/workflows/single_read_snv/tasks/mrd.wdl
@@ -40,7 +40,7 @@ task MrdDataAnalysis {
   >>>
   runtime {
     preemptible: 0
-    cpu: "~{cpus}"
+    cpu: cpus
     memory: "~{memory_gb} GB"
     disks: "local-disk " + ceil(disk_size) + " HDD"
     docker: docker
@@ -84,7 +84,7 @@ task GenerateControlSignaturesFromDatabase {
   >>>
   runtime {
     preemptible: 0
-    cpu: "~{cpus}"
+    cpu: cpus
     memory: "~{memory_gb} GB"
     disks: "local-disk " + ceil(disk_size) + " HDD"
     docker: docker
@@ -144,7 +144,7 @@ task FeatureMapIntersectWithSignatures {
   >>>
   runtime {
     preemptible: 0
-    cpu: "~{cpus}"
+    cpu: cpus
     memory: "~{memory_gb} GB"
     disks: "local-disk " + ceil(disk_size) + " HDD"
     docker: docker
@@ -187,7 +187,7 @@ task BedIntersectAndExclude {
 
     runtime {
       preemptible: "~{preemptibles}"
-      cpu: "~{cpus}"
+      cpu: cpus
       memory: "~{memory_gb} GB"
       disks: "local-disk " + ceil(disk_size) + " HDD"
       docker: docker
@@ -225,7 +225,7 @@ task MergeVcfsIntoBed {
 
     runtime {
       preemptible: "~{preemptibles}"
-      cpu: "~{cpus}"
+      cpu: cpus
       memory: "~{memory_gb} GB"
       disks: "local-disk " + ceil(disk_size) + " HDD"
       docker: docker
@@ -292,7 +292,7 @@ task ExtractCoverageOverVcfFiles {
 
     runtime {
       preemptible: "~{preemptibles}"
-      cpu: "~{cpus}"
+      cpu: cpus
       memory: "~{memory_gb} GB"
       disks: "local-disk " + ceil(disk_size) + " HDD"
       docker: docker
@@ -341,7 +341,7 @@ task PadVcf {
   
   runtime {
     preemptible: preemptible_tries
-    cpu: "~{cpus}"
+    cpu: cpus
     memory: "~{memory_gb} GB"
     disks: "local-disk " + disk_size + " HDD"
     docker: docker

--- a/workflows/single_read_snv/tasks/qc_tasks.wdl
+++ b/workflows/single_read_snv/tasks/qc_tasks.wdl
@@ -508,7 +508,7 @@ task CollectIntervalCoverageStats {
 
     runtime {
         preemptible: preemptible_tries
-        cpu: "16"
+        cpu: 16
         memory: "16 GB"
         disks: "local-disk " + coverage_stats_disk + " LOCAL"
         docker: docker
@@ -613,7 +613,7 @@ task FastQC {
   runtime
   {
     docker: docker
-    cpu: "~{cpu}"
+    cpu: cpu
     memory: "~{memory_gb} GB"
     disks: "local-disk " + disk_size + " " + disk_type
     noAddress: no_address
@@ -651,7 +651,7 @@ task CreateReportSingleSampleQC {
         preemptible: preemptible_tries
         memory: "3 GB"
         docker: docker
-        cpu: "1"
+        cpu: 1
         disks: "local-disk " + ceil(disk_size) + " HDD"
         noAddress: true
         maxRetries: preemptible_tries

--- a/workflows/somatic_snvfind/tasks/general_tasks.wdl
+++ b/workflows/somatic_snvfind/tasks/general_tasks.wdl
@@ -324,7 +324,7 @@ task IntervalListOfGenome {
 
   runtime {
     preemptible: preemptible_tries
-    cpu: "1"
+    cpu: 1
     memory: "1 GB"
     disks: "local-disk " + disk_size + " HDD"
     docker: docker
@@ -359,7 +359,7 @@ task IntervalListFromString {
   >>>
   runtime {
     preemptible: preemptible_tries
-    cpu: "1"
+    cpu: 1
     memory: "1 GB"
     disks: "local-disk " + disk_size + " HDD"
     docker: docker
@@ -395,7 +395,7 @@ task IntervalListTotalLength {
   }
 
    runtime {
-    cpu: "1"
+    cpu: 1
     memory: "1 GB"
     disks: "local-disk " + 4 + " HDD"
     docker: docker
@@ -422,7 +422,7 @@ task FastaLengthFromIndex {
   }
 
    runtime {
-    cpu: "1"
+    cpu: 1
     memory: "1 GB"
     disks: "local-disk " + 4 + " HDD"
     docker: docker
@@ -530,7 +530,7 @@ task DownsampleCramBam {
     >>>
     runtime {
         disks: "local-disk " + disk_size + " HDD"
-        cpu: "~{cpus}"
+        cpu: cpus
         memory: "~{memory_gb} GB"
         preemptible: preemptibles
         docker: docker
@@ -631,7 +631,7 @@ task ConcatHtmls {
         preemptible: preemptible_tries
         memory: "2 GB"
         docker: docker
-        cpu: "1"
+        cpu: 1
         disks: "local-disk " + ceil(disk_size) + " HDD"
         noAddress: true
     }
@@ -700,7 +700,7 @@ task RenameSampleInBam {
     runtime {
         preemptible: preemptible_tries
         memory: "2 GB"
-        cpu: "1"
+        cpu: 1
         disks: "local-disk " + disk_size + " LOCAL"
         docker: docker
         noAddress: no_address
@@ -748,7 +748,7 @@ task MergeCramFiles {
             disks: "local-disk " + (ceil(size(cache_tarball, "GB") + size(crams, "GB")) * 3 + 10) + " HDD"
             docker: docker
             noAddress: no_address
-            cpu: "~{cpus_to_use}"
+            cpu: cpus_to_use
             preemptible: preemptible_tries
 
     }
@@ -773,7 +773,7 @@ task MergeBams {
     runtime {
         preemptible: preemptible_tries
         memory: "16 GB"
-        cpu: "8"
+        cpu: 8
         disks: "local-disk " + disk_size + " LOCAL"
         docker: docker
         noAddress: no_address
@@ -970,7 +970,7 @@ task FilterVcfWithBcftools {
         memory: "~{memory_gb} GB"
         disks: "local-disk " + disk_size + " HDD"
         docker: docker
-        cpu: "~{cpus}"
+        cpu: cpus
         preemptible: preemptible_tries
     }
 }
@@ -1027,7 +1027,7 @@ task ExtractSorterStatsMetrics {
         preemptible: preemptible_tries
         memory: "2 GB"
         docker: docker
-        cpu: "1"
+        cpu: 1
     }
     output {
         Float mean_coverage = read_float("~{mean_coverage_output_file}")
@@ -1048,7 +1048,7 @@ task CopyFiles {
         docker: docker
         preemptible: 1
         memory: "2 GB"
-        cpu: "1"
+        cpu: 1
         disks: "local-disk " +ceil(2*size(input_files,"GB") + 1) + " HDD"
         noAddress: true
     }
@@ -1222,7 +1222,7 @@ task ConcatFiles{
     runtime {
         disks: "local-disk " + ceil(disk_size) + " HDD"
         docker: docker
-        cpu:1
+        cpu: 1
     }
     output{
         File out_merged_file = "~{out_file_name}"

--- a/workflows/structural_variant_pipeline/tasks/alignment_tasks.wdl
+++ b/workflows/structural_variant_pipeline/tasks/alignment_tasks.wdl
@@ -31,7 +31,7 @@ task SplitCram {
     runtime {
         preemptible: preemptible_tries
         memory: "8 GB"
-        cpu: "1"
+        cpu: 1
         disks: "local-disk " + disk_size + " LOCAL"
         docker: docker
         noAddress: no_address
@@ -115,7 +115,7 @@ task CreateReferenceCache {
     runtime {
         preemptible: preemptible_tries
         memory: "4 GB"
-        cpu: "2"
+        cpu: 2
         disks: "local-disk " + disk_size + " HDD"
         docker: docker
         maxRetries: 1
@@ -177,7 +177,7 @@ task ConvertCramOrBamToUBam {
     runtime {
         preemptible: preemptible_tries
         memory: "13 GB"
-        cpu: "3"
+        cpu: 3
         disks: "local-disk " + disk_size + " HDD"
         docker: docker
         noAddress: no_address
@@ -272,7 +272,7 @@ task SamToFastqAndBwaMemAndMba {
     runtime {
         preemptible: preemptible_tries
         memory: "28 GB"
-        cpu: "16"
+        cpu: 16
         disks: "local-disk " + disk_size + " HDD"
         docker: docker
         noAddress: no_address
@@ -365,7 +365,7 @@ task SamToFastqAndBwaMeth {
     runtime {
         preemptible: preemptible_tries
         memory: "32 GB"
-        cpu: "25"
+        cpu: 25
         disks: "local-disk " + disk_size + " HDD"
         docker: docker
         noAddress: no_address
@@ -409,7 +409,7 @@ task BuildUaIndex{
     >>>
 
     runtime {
-        cpu : "1"
+        cpu: 1
         cpuPlatform: "Intel Skylake"
         preemptible: preemptible_tries
         memory: "200 GB"
@@ -456,7 +456,7 @@ task BuildUaMethIndex {
     >>>
 
     runtime {
-        cpu : "1"
+        cpu: 1
         preemptible: preemptible_tries
         memory: "200 GB"
         disks: "local-disk " + disk_size + " HDD"
@@ -534,7 +534,7 @@ task AlignWithUA {
         cpuPlatform: "Intel Skylake"
         preemptible: preemptible_tries_final
         memory: "~{memory_gb} GiB"
-        cpu: "~{cpu}"
+        cpu: cpu
         disks: "local-disk " + disk_size + " HDD"
         docker: ua_docker
         noAddress: no_address
@@ -615,7 +615,7 @@ task AlignWithUAMeth {
         cpuPlatform: "Intel Skylake"
         preemptible: preemptible_tries_final
         memory: "~{memory_gb} GiB"
-        cpu: "~{cpu}"
+        cpu: cpu
         disks: "local-disk " + disk_size + " HDD"
         docker: ua_docker
         noAddress: no_address
@@ -897,7 +897,7 @@ task ConvertToCram {
     runtime {
         preemptible: preemptible_tries
         memory: "8 GB"
-        cpu: "1"
+        cpu: 1
         disks: "local-disk " + disk_size + " HDD"
         docker: docker
         maxRetries: 1
@@ -1012,7 +1012,7 @@ task StarAlign {
 
     runtime {
         preemptible: "~{preemptible_tries}"
-        cpu: "~{cpu}"
+        cpu: cpu
         memory: "~{memory_gb} GB"
         disks: "local-disk " + ceil(disk_size) + " HDD"
         docker: docker
@@ -1068,7 +1068,7 @@ task StarGenomeGenerate {
 
     runtime {
         preemptible: "~{preemptible_tries}"
-        cpu: "~{cpu}"
+        cpu: cpu
         memory: "40 GB"
         disks: "local-disk " + ceil(disk_size) + " HDD"
         docker: docker
@@ -1127,7 +1127,7 @@ task StarAlignStats {
     >>>
     runtime {
         preemptible: "~{preemptible_tries}"
-        cpu: "1"
+        cpu: 1
         memory: "8 GB"
         disks: "local-disk " + ceil(disk_size) + " HDD"
         docker: docker
@@ -1161,7 +1161,7 @@ task SortBam {
             SORT_ORDER=~{sort_order}
     >>>
     runtime {
-        cpu: "1"
+        cpu: 1
         memory: "8 GB"
         disks: "local-disk " + ceil(disk_size) + " HDD"
         docker: docker
@@ -1192,7 +1192,7 @@ task IndexBam {
         samtools index ~{input_bam}
     >>>  
     runtime {
-        cpu: "1"
+        cpu: 1
         memory: "8 GB"
         disks: "local-disk " + ceil(disk_size) + " HDD"
         docker: docker

--- a/workflows/structural_variant_pipeline/tasks/general_tasks.wdl
+++ b/workflows/structural_variant_pipeline/tasks/general_tasks.wdl
@@ -324,7 +324,7 @@ task IntervalListOfGenome {
 
   runtime {
     preemptible: preemptible_tries
-    cpu: "1"
+    cpu: 1
     memory: "1 GB"
     disks: "local-disk " + disk_size + " HDD"
     docker: docker
@@ -359,7 +359,7 @@ task IntervalListFromString {
   >>>
   runtime {
     preemptible: preemptible_tries
-    cpu: "1"
+    cpu: 1
     memory: "1 GB"
     disks: "local-disk " + disk_size + " HDD"
     docker: docker
@@ -395,7 +395,7 @@ task IntervalListTotalLength {
   }
 
    runtime {
-    cpu: "1"
+    cpu: 1
     memory: "1 GB"
     disks: "local-disk " + 4 + " HDD"
     docker: docker
@@ -422,7 +422,7 @@ task FastaLengthFromIndex {
   }
 
    runtime {
-    cpu: "1"
+    cpu: 1
     memory: "1 GB"
     disks: "local-disk " + 4 + " HDD"
     docker: docker
@@ -530,7 +530,7 @@ task DownsampleCramBam {
     >>>
     runtime {
         disks: "local-disk " + disk_size + " HDD"
-        cpu: "~{cpus}"
+        cpu: cpus
         memory: "~{memory_gb} GB"
         preemptible: preemptibles
         docker: docker
@@ -631,7 +631,7 @@ task ConcatHtmls {
         preemptible: preemptible_tries
         memory: "2 GB"
         docker: docker
-        cpu: "1"
+        cpu: 1
         disks: "local-disk " + ceil(disk_size) + " HDD"
         noAddress: true
     }
@@ -700,7 +700,7 @@ task RenameSampleInBam {
     runtime {
         preemptible: preemptible_tries
         memory: "2 GB"
-        cpu: "1"
+        cpu: 1
         disks: "local-disk " + disk_size + " LOCAL"
         docker: docker
         noAddress: no_address
@@ -748,7 +748,7 @@ task MergeCramFiles {
             disks: "local-disk " + (ceil(size(cache_tarball, "GB") + size(crams, "GB")) * 3 + 10) + " HDD"
             docker: docker
             noAddress: no_address
-            cpu: "~{cpus_to_use}"
+            cpu: cpus_to_use
             preemptible: preemptible_tries
 
     }
@@ -773,7 +773,7 @@ task MergeBams {
     runtime {
         preemptible: preemptible_tries
         memory: "16 GB"
-        cpu: "8"
+        cpu: 8
         disks: "local-disk " + disk_size + " LOCAL"
         docker: docker
         noAddress: no_address
@@ -970,7 +970,7 @@ task FilterVcfWithBcftools {
         memory: "~{memory_gb} GB"
         disks: "local-disk " + disk_size + " HDD"
         docker: docker
-        cpu: "~{cpus}"
+        cpu: cpus
         preemptible: preemptible_tries
     }
 }
@@ -1027,7 +1027,7 @@ task ExtractSorterStatsMetrics {
         preemptible: preemptible_tries
         memory: "2 GB"
         docker: docker
-        cpu: "1"
+        cpu: 1
     }
     output {
         Float mean_coverage = read_float("~{mean_coverage_output_file}")
@@ -1048,7 +1048,7 @@ task CopyFiles {
         docker: docker
         preemptible: 1
         memory: "2 GB"
-        cpu: "1"
+        cpu: 1
         disks: "local-disk " +ceil(2*size(input_files,"GB") + 1) + " HDD"
         noAddress: true
     }
@@ -1222,7 +1222,7 @@ task ConcatFiles{
     runtime {
         disks: "local-disk " + ceil(disk_size) + " HDD"
         docker: docker
-        cpu:1
+        cpu: 1
     }
     output{
         File out_merged_file = "~{out_file_name}"

--- a/workflows/trim_align_sort/tasks/alignment_tasks.wdl
+++ b/workflows/trim_align_sort/tasks/alignment_tasks.wdl
@@ -31,7 +31,7 @@ task SplitCram {
     runtime {
         preemptible: preemptible_tries
         memory: "8 GB"
-        cpu: "1"
+        cpu: 1
         disks: "local-disk " + disk_size + " LOCAL"
         docker: docker
         noAddress: no_address
@@ -115,7 +115,7 @@ task CreateReferenceCache {
     runtime {
         preemptible: preemptible_tries
         memory: "4 GB"
-        cpu: "2"
+        cpu: 2
         disks: "local-disk " + disk_size + " HDD"
         docker: docker
         maxRetries: 1
@@ -177,7 +177,7 @@ task ConvertCramOrBamToUBam {
     runtime {
         preemptible: preemptible_tries
         memory: "13 GB"
-        cpu: "3"
+        cpu: 3
         disks: "local-disk " + disk_size + " HDD"
         docker: docker
         noAddress: no_address
@@ -272,7 +272,7 @@ task SamToFastqAndBwaMemAndMba {
     runtime {
         preemptible: preemptible_tries
         memory: "28 GB"
-        cpu: "16"
+        cpu: 16
         disks: "local-disk " + disk_size + " HDD"
         docker: docker
         noAddress: no_address
@@ -365,7 +365,7 @@ task SamToFastqAndBwaMeth {
     runtime {
         preemptible: preemptible_tries
         memory: "32 GB"
-        cpu: "25"
+        cpu: 25
         disks: "local-disk " + disk_size + " HDD"
         docker: docker
         noAddress: no_address
@@ -409,7 +409,7 @@ task BuildUaIndex{
     >>>
 
     runtime {
-        cpu : "1"
+        cpu: 1
         cpuPlatform: "Intel Skylake"
         preemptible: preemptible_tries
         memory: "200 GB"
@@ -456,7 +456,7 @@ task BuildUaMethIndex {
     >>>
 
     runtime {
-        cpu : "1"
+        cpu: 1
         preemptible: preemptible_tries
         memory: "200 GB"
         disks: "local-disk " + disk_size + " HDD"
@@ -534,7 +534,7 @@ task AlignWithUA {
         cpuPlatform: "Intel Skylake"
         preemptible: preemptible_tries_final
         memory: "~{memory_gb} GiB"
-        cpu: "~{cpu}"
+        cpu: cpu
         disks: "local-disk " + disk_size + " HDD"
         docker: ua_docker
         noAddress: no_address
@@ -615,7 +615,7 @@ task AlignWithUAMeth {
         cpuPlatform: "Intel Skylake"
         preemptible: preemptible_tries_final
         memory: "~{memory_gb} GiB"
-        cpu: "~{cpu}"
+        cpu: cpu
         disks: "local-disk " + disk_size + " HDD"
         docker: ua_docker
         noAddress: no_address
@@ -897,7 +897,7 @@ task ConvertToCram {
     runtime {
         preemptible: preemptible_tries
         memory: "8 GB"
-        cpu: "1"
+        cpu: 1
         disks: "local-disk " + disk_size + " HDD"
         docker: docker
         maxRetries: 1
@@ -1012,7 +1012,7 @@ task StarAlign {
 
     runtime {
         preemptible: "~{preemptible_tries}"
-        cpu: "~{cpu}"
+        cpu: cpu
         memory: "~{memory_gb} GB"
         disks: "local-disk " + ceil(disk_size) + " HDD"
         docker: docker
@@ -1068,7 +1068,7 @@ task StarGenomeGenerate {
 
     runtime {
         preemptible: "~{preemptible_tries}"
-        cpu: "~{cpu}"
+        cpu: cpu
         memory: "40 GB"
         disks: "local-disk " + ceil(disk_size) + " HDD"
         docker: docker
@@ -1127,7 +1127,7 @@ task StarAlignStats {
     >>>
     runtime {
         preemptible: "~{preemptible_tries}"
-        cpu: "1"
+        cpu: 1
         memory: "8 GB"
         disks: "local-disk " + ceil(disk_size) + " HDD"
         docker: docker
@@ -1161,7 +1161,7 @@ task SortBam {
             SORT_ORDER=~{sort_order}
     >>>
     runtime {
-        cpu: "1"
+        cpu: 1
         memory: "8 GB"
         disks: "local-disk " + ceil(disk_size) + " HDD"
         docker: docker
@@ -1192,7 +1192,7 @@ task IndexBam {
         samtools index ~{input_bam}
     >>>  
     runtime {
-        cpu: "1"
+        cpu: 1
         memory: "8 GB"
         disks: "local-disk " + ceil(disk_size) + " HDD"
         docker: docker

--- a/workflows/trim_align_sort/tasks/general_tasks.wdl
+++ b/workflows/trim_align_sort/tasks/general_tasks.wdl
@@ -324,7 +324,7 @@ task IntervalListOfGenome {
 
   runtime {
     preemptible: preemptible_tries
-    cpu: "1"
+    cpu: 1
     memory: "1 GB"
     disks: "local-disk " + disk_size + " HDD"
     docker: docker
@@ -359,7 +359,7 @@ task IntervalListFromString {
   >>>
   runtime {
     preemptible: preemptible_tries
-    cpu: "1"
+    cpu: 1
     memory: "1 GB"
     disks: "local-disk " + disk_size + " HDD"
     docker: docker
@@ -395,7 +395,7 @@ task IntervalListTotalLength {
   }
 
    runtime {
-    cpu: "1"
+    cpu: 1
     memory: "1 GB"
     disks: "local-disk " + 4 + " HDD"
     docker: docker
@@ -422,7 +422,7 @@ task FastaLengthFromIndex {
   }
 
    runtime {
-    cpu: "1"
+    cpu: 1
     memory: "1 GB"
     disks: "local-disk " + 4 + " HDD"
     docker: docker
@@ -530,7 +530,7 @@ task DownsampleCramBam {
     >>>
     runtime {
         disks: "local-disk " + disk_size + " HDD"
-        cpu: "~{cpus}"
+        cpu: cpus
         memory: "~{memory_gb} GB"
         preemptible: preemptibles
         docker: docker
@@ -631,7 +631,7 @@ task ConcatHtmls {
         preemptible: preemptible_tries
         memory: "2 GB"
         docker: docker
-        cpu: "1"
+        cpu: 1
         disks: "local-disk " + ceil(disk_size) + " HDD"
         noAddress: true
     }
@@ -700,7 +700,7 @@ task RenameSampleInBam {
     runtime {
         preemptible: preemptible_tries
         memory: "2 GB"
-        cpu: "1"
+        cpu: 1
         disks: "local-disk " + disk_size + " LOCAL"
         docker: docker
         noAddress: no_address
@@ -748,7 +748,7 @@ task MergeCramFiles {
             disks: "local-disk " + (ceil(size(cache_tarball, "GB") + size(crams, "GB")) * 3 + 10) + " HDD"
             docker: docker
             noAddress: no_address
-            cpu: "~{cpus_to_use}"
+            cpu: cpus_to_use
             preemptible: preemptible_tries
 
     }
@@ -773,7 +773,7 @@ task MergeBams {
     runtime {
         preemptible: preemptible_tries
         memory: "16 GB"
-        cpu: "8"
+        cpu: 8
         disks: "local-disk " + disk_size + " LOCAL"
         docker: docker
         noAddress: no_address
@@ -970,7 +970,7 @@ task FilterVcfWithBcftools {
         memory: "~{memory_gb} GB"
         disks: "local-disk " + disk_size + " HDD"
         docker: docker
-        cpu: "~{cpus}"
+        cpu: cpus
         preemptible: preemptible_tries
     }
 }
@@ -1027,7 +1027,7 @@ task ExtractSorterStatsMetrics {
         preemptible: preemptible_tries
         memory: "2 GB"
         docker: docker
-        cpu: "1"
+        cpu: 1
     }
     output {
         Float mean_coverage = read_float("~{mean_coverage_output_file}")
@@ -1048,7 +1048,7 @@ task CopyFiles {
         docker: docker
         preemptible: 1
         memory: "2 GB"
-        cpu: "1"
+        cpu: 1
         disks: "local-disk " +ceil(2*size(input_files,"GB") + 1) + " HDD"
         noAddress: true
     }
@@ -1222,7 +1222,7 @@ task ConcatFiles{
     runtime {
         disks: "local-disk " + ceil(disk_size) + " HDD"
         docker: docker
-        cpu:1
+        cpu: 1
     }
     output{
         File out_merged_file = "~{out_file_name}"

--- a/workflows/trim_align_sort/tasks/qc_tasks.wdl
+++ b/workflows/trim_align_sort/tasks/qc_tasks.wdl
@@ -508,7 +508,7 @@ task CollectIntervalCoverageStats {
 
     runtime {
         preemptible: preemptible_tries
-        cpu: "16"
+        cpu: 16
         memory: "16 GB"
         disks: "local-disk " + coverage_stats_disk + " LOCAL"
         docker: docker
@@ -613,7 +613,7 @@ task FastQC {
   runtime
   {
     docker: docker
-    cpu: "~{cpu}"
+    cpu: cpu
     memory: "~{memory_gb} GB"
     disks: "local-disk " + disk_size + " " + disk_type
     noAddress: no_address
@@ -651,7 +651,7 @@ task CreateReportSingleSampleQC {
         preemptible: preemptible_tries
         memory: "3 GB"
         docker: docker
-        cpu: "1"
+        cpu: 1
         disks: "local-disk " + ceil(disk_size) + " HDD"
         noAddress: true
         maxRetries: preemptible_tries

--- a/workflows/trim_align_sort/tasks/sorting_tasks.wdl
+++ b/workflows/trim_align_sort/tasks/sorting_tasks.wdl
@@ -129,7 +129,7 @@ task Demux {
     >>>
     runtime {
         cpuPlatform: "Intel Skylake"
-        cpu: "~{cpu}"
+        cpu: cpu
         preemptible: preemptible_tries_final
         memory: "~{memory_gb} GiB"
         disks: "local-disk " + ceil(mapped_bam_size_local_ssd) + " LOCAL"
@@ -293,7 +293,7 @@ task Sorter {
     >>>
     runtime {
         cpuPlatform: "Intel Skylake"
-        cpu: "~{cpu}"
+        cpu: cpu
         preemptible: preemptible_tries_final
         memory: "~{memory_gb} GiB"
         disks: "local-disk " + ceil(mapped_bam_size_local_ssd) + " LOCAL"
@@ -371,7 +371,7 @@ task ConvertToFastq {
     >>>
     runtime {
         cpuPlatform: "Intel Skylake"
-        cpu: "~{cpu}"
+        cpu: cpu
         preemptible: preemptible_tries
         memory: "16 GiB"
         disks: "local-disk " + ceil(local_ssd_size_ask) + " LOCAL"

--- a/workflows/trim_align_sort/tasks/trimming_tasks.wdl
+++ b/workflows/trim_align_sort/tasks/trimming_tasks.wdl
@@ -174,7 +174,7 @@ task Trimmer {
     >>>
     runtime {
         cpuPlatform: "Intel Skylake"
-        cpu: "~{cpus}"
+        cpu: cpus
         preemptible: preemptible_tries
         memory: "~{memory_gb} GB"
         disks: "local-disk " + ceil(disk_size) + " HDD"
@@ -228,7 +228,7 @@ task TrimmerAggregateStats {
     >>>
     runtime {
         preemptible: preemptible_tries
-        cpu: "1"
+        cpu: 1
         memory: "5 GB"
         disks: "local-disk " + ceil(disk_size) + " HDD"
         docker: docker
@@ -281,7 +281,7 @@ task CutadaptMarkAdapter {
     }
 
     runtime {
-        cpu: "~{cpus}"
+        cpu: cpus
         memory: "~{memory_gb} GB"
         docker: docker
         noAddress: no_address


### PR DESCRIPTION
We're working on getting [Sprocket](https://github.com/stjude-rust-labs/sprocket) to parse and lint this repository, and we're systematically working through the issues it reports. This PR addresses the largest category of errors by far (324 of 366 total).

The `cpu` runtime key was set to `String` values throughout the task files—either literal strings like `"1"` or interpolated strings like `"~{cpus}"`. The WDL 1.0 spec doesn't define what type `cpu` should be, but WDL 1.1 specifies it as `Int` or `Float`, which is what Sprocket enforces. Since Cromwell also supports `Int` natively and only handles `String` values here through implicit coercion, using `Int` directly is the safest choice across engines.

This also normalizes spacing on `cpu` lines (e.g., `cpu : 1` and `cpu:1` are now consistently `cpu: 1`).