### PR TITLE
DATA-9429: feat(healthomics): add genome_resources.wdl localization support

### DIFF
--- a/scripts/healthomics_wf/create_healthomics_workflow.py
+++ b/scripts/healthomics_wf/create_healthomics_workflow.py
@@ -10,6 +10,7 @@ log_format = "[%(levelname)s] %(message)s"
 logging.basicConfig(level=logging.INFO, format=log_format)
 
 GLOBALS_WDL = "tasks/globals.wdl"
+GENOME_RESOURCES_WDL = "tasks/genome_resources.wdl"
 
 
 def localize_workflow(wf_root, aws_region, s3_bucket, aws_profile=None, input_template=None):
@@ -24,6 +25,10 @@ def localize_workflow(wf_root, aws_region, s3_bucket, aws_profile=None, input_te
     else:
         files_to_localize_s3 = glob.glob(f'{wf_root}/input_templates/*.json')
     files_to_localize_s3.append(globals_wdl_file)
+
+    genome_resources_file = f"{wf_root}/{GENOME_RESOURCES_WDL}"
+    if Path(genome_resources_file).exists():
+        files_to_localize_s3.append(genome_resources_file)
 
     for input_file in files_to_localize_s3:
         logging.info(f"localizing {input_file}")


### PR DESCRIPTION
Why this change was needed:
Some workflows now have a genome_resources.wdl file containing S3 paths to reference genome files that need to be localized to the destination bucket before creating HealthOmics workflows.

What changed:
- Added GENOME_RESOURCES_WDL constant for the file path
- Added conditional logic to include genome_resources.wdl in S3 localization when the file exists in a workflow's tasks folder

Problem solved:
Workflows with genome_resources.wdl (8 of 16 workflows) now have their S3 paths properly localized, while workflows without this file continue to work unchanged.

Refs: DATA-9429

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a small conditional to localize an extra WDL file when present, without changing workflow creation or existing localization paths for workflows that lack it.
> 
> **Overview**
> HealthOmics workflow localization now also checks for `tasks/genome_resources.wdl` and, when present, runs it through the existing `localize_s3_files` step so its S3 paths are copied/rewritten into the destination bucket.
> 
> Workflows without this file are unchanged; localization still always processes input templates and `tasks/globals.wdl` as before.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 36d35464acc43c68e8b63cd98228d1a46eba1a14. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->