### PR TITLE
Update ready to run pipelines to be irrelevant

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,9 @@ UltimaGenomics repository for workflows compatible with AWS HealthOmics
 6. [Support Tools](#Support-Tools)
 ## Introduction
 
-1.	Ultima Genomics offers pipelines as Ready2Run workflows on AWS HealthOmics. Ready2Run workflows enable you to run these pipelines on AWS HealthOmics by simply bringing your data. For more flexibility such as the use of larger file sizes or changing the reference genome, you can convert Ready2Run workflows to private workflows by following the steps in this repository. Once the Ready2Run workflow is converted to a private workflow, the cost to run the workflow will now be based on the compute and run storage used during the private workflow.
-
-2.	Ultima Genomics also shares pipelines that has been modified to run as private workflows on AWS HealthOmics in this repository. You can follow the directions in this repository to create and run a private workflow on AWS HealthOmics.
+1.	This repository provides Ultima Genomics pipelines that have been adapted to run as private workflows on AWS HealthOmics. Follow the directions here to deploy and run private workflows, including cases where you need flexibility in resource configuration, references, and workflow inputs.
   
-3.	Each workflow folder contains the following:
+2.	Each workflow folder contains the following:
     - required wdl file\s
     - HowTo documentation that details the workflow flow and how to run it externally of wdl
     - documentation of the wdl inputs and outputs
@@ -22,7 +20,8 @@ UltimaGenomics repository for workflows compatible with AWS HealthOmics
     - folder with optional input templates with default parameters for the wdl
     - folder with the different tasks the wdl is running
 
-4. The instructions below include localizing resources, deploying workflow and creating a run.
+3. The instructions below include localizing resources, deploying workflow and creating a run.
+4. Warning: the current Ready2Run workflows on AWS HealthOmics are associated with pipelines that are not relevant for use with this repository. Do not use Ready2Run as the recommended path for these workflows.
 5. For more questions about these workflows, please contact healthomics.support@ultimagen.com.
 
 ## Terraform Modules for Environment Setup


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that updates positioning and guidance around using private workflows vs. Ready2Run.
> 
> **Overview**
> Updates `README.md` to reposition the repo as **private-workflow-focused** (removing the prior Ready2Run conversion framing) and adds an explicit warning that existing AWS HealthOmics Ready2Run workflows are *not relevant* for this repository and should not be used as the recommended path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6acfa4797f4a3e86c120f12100bdc00fdffea49f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->